### PR TITLE
Fix loading preferences when disconnected

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
@@ -24,6 +24,7 @@ import android.net.wifi.WifiManager;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.google.android.material.timepicker.MaterialTimePicker;
@@ -591,6 +592,7 @@ public final class Preferences {
         return string == null ? CustomizeShortcutsMode.ENABLED : CustomizeShortcutsMode.valueOf(string);
     }
 
+    @NonNull
     public List<String> getArchivedMenuItems(Player player) {
         List<String> list = new ArrayList<>();
         String string = sharedPreferences.getString(String.format(KEY_PLAYER_ARCHIVED_ITEMS_FORMAT, player.getId()), null);

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -359,7 +359,10 @@ public class SqueezeService extends Service {
             if (homeMenu.size() == count) {
                 Preferences preferences = new Preferences(SqueezeService.this);
                 boolean useArchive = preferences.getCustomizeHomeMenuMode() != Preferences.CustomizeHomeMenuMode.DISABLED;
-                List<String> archivedMenuItems = useArchive ? preferences.getArchivedMenuItems(mDelegate.getActivePlayer()) : Collections.emptyList();
+                List<String> archivedMenuItems = Collections.emptyList();
+                if ((useArchive) && (mDelegate.getActivePlayer() != null)) {
+                    archivedMenuItems = preferences.getArchivedMenuItems(mDelegate.getActivePlayer());
+                }
                 Map<String, Map<String, Object>> customShortcuts = preferences.restoreCustomShortcuts();
                 mDelegate.setHomeMenu(homeMenu, archivedMenuItems, customShortcuts);
             }
@@ -1366,7 +1369,10 @@ public class SqueezeService extends Service {
             if (Preferences.KEY_CUSTOMIZE_HOME_MENU_MODE.equals(key)) {
                 Preferences preferences = new Preferences(SqueezeService.this);
                 boolean useArchive = preferences.getCustomizeHomeMenuMode() != Preferences.CustomizeHomeMenuMode.DISABLED;
-                List<String> archivedMenuItems = useArchive ? preferences.getArchivedMenuItems(getActivePlayer()) : Collections.emptyList();
+                List<String> archivedMenuItems = Collections.emptyList();
+                if ((useArchive) && (getActivePlayer() != null)) {
+                    archivedMenuItems = preferences.getArchivedMenuItems(getActivePlayer());
+                }
                 Map<String, Map<String, Object>> customShortcuts = preferences.restoreCustomShortcuts();
                 mDelegate.setHomeMenu(archivedMenuItems, customShortcuts);
             }


### PR DESCRIPTION
When disconnected, no player is available. If preferences depend upon player, return empty list. The correct data will be loaded when the player will be connected. Added annotation.