### PR TITLE
Fix for Random Play with several players and attempted fix for breakdown of random play after about 60 minutes

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Player.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Player.java
@@ -42,10 +42,6 @@ public class Player extends Item implements Comparable<Player> {
     /** Is the player connected? */
     private boolean mConnected;
 
-    /** Is the player playing the tracks of a filesystem folder randomly **/
-    // TODO persist mRandomPlaying in PlayerState
-    private boolean mRandomPlaying;
-
     @Override
     public int compareTo(@NonNull Player otherPlayer) {
         return this.mName.compareToIgnoreCase((otherPlayer).mName);
@@ -206,13 +202,5 @@ public class Player extends Item implements Comparable<Player> {
 
     public boolean isSyncVolume() {
         return "1".equals(getPlayerState().prefs.get(Player.Pref.SYNC_VOLUME));
-    }
-
-    public boolean isRandomPlaying() {
-        return mRandomPlaying;
-    }
-
-    public void setRandomPlaying(boolean b) {
-        mRandomPlaying = b;
     }
 }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/PlayerState.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/PlayerState.java
@@ -74,6 +74,7 @@ public class PlayerState implements Parcelable {
         source.readStringList(mSyncSlaves);
         mPlayerSubscriptionType = PlayerSubscriptionType.valueOf(source.readString());
         prefs = source.readHashMap(getClass().getClassLoader());
+        mRandomPlaying =(source.readByte() == 1);
     }
 
     @Override
@@ -95,6 +96,7 @@ public class PlayerState implements Parcelable {
         dest.writeStringList(mSyncSlaves);
         dest.writeString(mPlayerSubscriptionType.name());
         dest.writeMap(prefs);
+        dest.writeByte(mRandomPlaying ? (byte) 1 : (byte) 0);
     }
 
     @Override
@@ -139,6 +141,9 @@ public class PlayerState implements Parcelable {
     private int sleepDuration;
 
     private double sleep;
+
+    /** Is the player playing the tracks of a filesystem folder randomly (via context menu) **/
+    private boolean mRandomPlaying;
 
     /** The player this player is synced to (null if none). */
     @Nullable
@@ -397,6 +402,15 @@ public class PlayerState implements Parcelable {
         mPlayerSubscriptionType = type;
     }
 
+    public boolean isRandomPlaying() {
+        return mRandomPlaying;
+    }
+
+    private static final String TAG = "PlayerState";
+    public void setRandomPlaying(boolean b) {
+        mRandomPlaying = b;
+    }
+
     @StringDef({PLAY_STATE_PLAY, PLAY_STATE_PAUSE, PLAY_STATE_STOP})
     @Retention(RetentionPolicy.SOURCE)
     public @interface PlayState {}
@@ -422,6 +436,7 @@ public class PlayerState implements Parcelable {
                 ", mSyncMaster='" + mSyncMaster + '\'' +
                 ", mSyncSlaves=" + mSyncSlaves +
                 ", mPlayerSubscriptionType='" + mPlayerSubscriptionType + '\'' +
+                ", mRandomPlaying='" + mRandomPlaying + '\'' +
                 '}';
     }
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/RandomPlay.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/RandomPlay.java
@@ -41,7 +41,7 @@ public class RandomPlay {
         this.firstFound = false;
         this.nextTrack = "";
         this.activeFolderID = "";
-        player.setRandomPlaying(false);
+        player.getPlayerState().setRandomPlaying(false);
     }
 
     String getNextTrack() {
@@ -113,7 +113,7 @@ public class RandomPlay {
                 // Generate playlist
                 rDelegate.fillPlaylist(new HashSet<>(rDelegate.getTracks(this.folderID)),
                         player, "no_ignore");
-                player.setRandomPlaying(true);
+                player.getPlayerState().setRandomPlaying(true);
             }
         }
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -764,8 +764,10 @@ public class SqueezeService extends Service {
         int index = playerState.getCurrentPlaylistIndex();
         String nextTrack = randomPlay.getNextTrack();
         if (endRandomPlay(number, index)) {
-            Log.v(TAG, "handleRandomOnEvent: End Random Play by not adding more tracks");
+            Log.v(TAG, String.format("handleRandomOnEvent: End Random Play and reset '%s'.", player.getName()));
             randomPlay.reset(player);
+        } else if (firstTwoTracksLoaded(number, index)) {
+            return;
         } else {
             String folderID = randomPlay.getActiveFolderID();
             Set<String> tracks = randomPlay.getTracks(folderID);
@@ -796,11 +798,11 @@ public class SqueezeService extends Service {
             // last track playing
             return false;
         }
-        else if ((number - index == 2) && (number == 1)) {
-            // handle situation after fast initialization
-            return false;
-        }
-        return true;
+        else return !firstTwoTracksLoaded(number, index);
+    }
+
+    private boolean firstTwoTracksLoaded(int number, int index) {
+        return (number - index == 2) && (number == 2);
     }
 
     public void onEvent(PlayersChanged event) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -749,7 +749,7 @@ public class SqueezeService extends Service {
         if (event.player.equals(mDelegate.getActivePlayer())) {
             updateOngoingNotification();
         }
-        if (event.player.isRandomPlaying()) {
+        if (event.player.getPlayerState().isRandomPlaying()) {
             handleRandomOnEvent(event.player);
         }
     }


### PR DESCRIPTION
Fixes an issue where the parallel start of several random plays resulted in inaccurate playlist generation upon start. There is still a problem with some kind of timeout after 30 minutes to 60 minutes I would guess which might be related to the app going to background. In that case the random play is ending and is not possible to resume. Mabe this is related to the fact that I currently not yet persist the random play status of the player. (I am fine with using this in beta as is, also because I can test more. People will not use it that much.)