### PR TITLE
Fix settings and translations

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
@@ -508,9 +508,9 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
 
     public void randomPlayFolder(JiveItem item) {
         if (!mService.randomPlayFolder(item)) {
-            showDisplayMessage("Unable to start Random Play");
+            showDisplayMessage(R.string.RANDOM_PLAY_UNABLE);
         } else {
-            showDisplayMessage("Random Play started");
+            showDisplayMessage(R.string.RANDOM_PLAY_STARTED);
         }
     }
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -764,8 +764,10 @@ public class SqueezeService extends Service {
         int index = playerState.getCurrentPlaylistIndex();
         String nextTrack = randomPlay.getNextTrack();
         if (endRandomPlay(number, index)) {
-            Log.v(TAG, "handleRandomOnEvent: End Random Play by not adding more tracks");
+            Log.v(TAG, String.format("handleRandomOnEvent: End Random Play and reset '%s'.", player.getName()));
             randomPlay.reset(player);
+        } else if (firstTwoTracksLoaded(number, index)) {
+            return;
         } else {
             String folderID = randomPlay.getActiveFolderID();
             Set<String> tracks = randomPlay.getTracks(folderID);
@@ -796,11 +798,11 @@ public class SqueezeService extends Service {
             // last track playing
             return false;
         }
-        else if ((number - index == 2) && (number == 1)) {
-            // handle situation after fast initialization
-            return false;
-        }
-        return true;
+        else return !firstTwoTracksLoaded(number, index);
+    }
+
+    private boolean firstTwoTracksLoaded(int number, int index) {
+        return (number - index == 2) && (number == 2);
     }
 
     public void onEvent(PlayersChanged event) {

--- a/Squeezer/src/main/res/values-da/strings.xml
+++ b/Squeezer/src/main/res/values-da/strings.xml
@@ -61,7 +61,6 @@
     <string name="settings_action_on_incoming_call_title">Handling når du modtager eller foretager et opkald</string>
     <string name="settings_no_action_on_incoming_call">No action</string>
 
-    <string name="settings_category_ui">Squeezer grænseflade</string>
     <string name="settings_customize_home_menu_mode">Arkiv</string>
     <string name="settings_customize_home_menu_info">Startmenuen i din Squeezebox og flere undermenuer kan tilpasses</string>
     <string name="settings_customize_home_menu_archive">Langt tryk på et emne flytter det til arkiv/fjerner det fra arkiv</string>

--- a/Squeezer/src/main/res/values-de/strings.xml
+++ b/Squeezer/src/main/res/values-de/strings.xml
@@ -33,10 +33,8 @@
     <string name="settings_theme_title">Erscheinungsbild</string>
     <string name="settings_theme_dark">Dunkel</string>
     <string name="settings_theme_light_dark">Hell, dunkle Aktionsleiste</string>
-    <string name="settings_clear_current_playlist_confirmation_off">Nicht vor dem Löschen der
-        aktuellen Wiedergabeliste nachfragen</string>
-    <string name="settings_clear_current_playlist_confirmation">Vor dem Löschen der aktuellen
-        Wiedergabeliste nachfragen</string>
+    <string name="settings_clear_current_playlist_confirmation_off">nicht nachfragen</string>
+    <string name="settings_clear_current_playlist_confirmation">Vor dem Löschen der Wiedergabeliste</string>
     <string name="settings_username_hint">Benutzername (optional)</string>
     <string name="settings_password_hint">Passwort (optional)</string>
     <string name="settings_use_wake_on_lan">Server aufwecken (Wake-on-LAN)</string>
@@ -72,12 +70,12 @@
     <string name="settings_squeezeplayer_title">Starte SqueezePlayer</string>
     <string name="settings_squeezeplayer_summary">Auswählen, um sicherzustellen, dass SqueezePlayer
         läuft, wenn Squeezer verwendet wird.</string>
-    <string name="settings_category_ui">Squeezer-Schnittstelle</string>
+    <string name="settings_category_ui">Shortcuts, Erscheinungsbild, etc.</string>
     <string name="settings_customize_home_menu_mode">Archiv</string>
-    <string name="settings_customize_home_menu_info">Startmenü und einige Untermenüs können angepasst werden.</string>
-    <string name="settings_customize_home_menu_archive">Langes Drücken archiviert/unarchiviert einen Menüpunkt</string>
-    <string name="settings_customize_home_menu_disabled">Archivfunktion deaktiviert</string>
-    <string name="settings_customize_home_menu_locked">Langes Drücken ist deaktiviert, aber Archivinhalte bleiben bestehen</string>
+    <string name="settings_customize_home_menu_info">Langes Drücken (un)archiviert den Menüeintrag</string>
+    <string name="settings_customize_home_menu_archive">Aktiviert</string>
+    <string name="settings_customize_home_menu_disabled">Deaktiviert</string>
+    <string name="settings_customize_home_menu_locked">Deaktiviert, aber Archivinhalte bleiben bestehen</string>
 
     <string name="menu_item_disconnect">Verbindung trennen</string>
     <string name="menu_item_connect">Verbinden</string>
@@ -219,25 +217,26 @@
     <string name="remote_preset5Description">Favoritentaste 5</string>
     <string name="remote_preset6Description">Favoritentaste 6</string>
     <string name="ARCHIVE_NODE">Archiv</string>
-    <string name="MENU_ITEM_MOVED">Menüpunkt verschoben</string>
+    <string name="MENU_ITEM_MOVED">Menüpunkt (un-)archiviert</string>
     <string name="MENU_IS_SUBMENU_IN_ARCHIVE">Sie befinden sich bereits im Archiv!</string>
     <string name="ARCHIVE_CANNOT_BE_ARCHIVED">Das Archiv kann nicht archviert werden!</string>
     <string name="ARCHIVE_NODE_REMOVED">Leeres Archiv aus dem Menü entfernt</string>
-    <string name="ITEM_CANNOT_BE_ARCHIVED">Kann nicht archiviert werden.</string>
-    <string name="settings_clear_current_playlist_confirmation_on">Beim Löschen der aktuellen Wiedergabeliste nachfragen</string>
+    <string name="ITEM_CANNOT_BE_ARCHIVED">Kann nicht archiviert werden!</string>
+    <string name="settings_clear_current_playlist_confirmation_on">nachfragen</string>
     <string name="CUSTOM_SHORTCUT_REMOVED">Shortcut entfernt</string>
     <string name="ITEM_IS_ALREADY_A_SHORTCUT">Ist bereits ein Shortcut!</string>
     <string name="ITEM_PUT_AS_SHORTCUT_ON_HOME_MENU">Shortcut auf Home Menü abgelegt</string>
     <string name="ITEM_CAN_NOT_BE_SHORTCUT_OR_ARCHIVED">Nicht archivierbar oder shortcutfähig!</string>
-    <string name="settings_custom_shortcut_enabled">Langes Drücken setzt Shortcut in Home Menü</string>
-    <string name="settings_custom_shortcut_disabled">Setzen von Shortcuts deaktiviert</string>
-    <string name="settings_custom_shortcut_locked">Langed Drücken setzt keinen Shortcut, aber bestehende bleiben.</string>
-    <string name="settings_customize_customShortcut_mode">Individuelle Shortcuts</string>
-    <string name="settings_customize_customShortcut_info">Langes Drücken setzt einen Shortcut im Home Menü.
-        (Bei Änderungen der Verzeichnisstruktur Shortcuts erneuern!)</string>
+    <string name="settings_custom_shortcut_enabled">Aktiviert</string>
+    <string name="settings_custom_shortcut_disabled">Deaktiviert</string>
+    <string name="settings_custom_shortcut_locked">Deaktiviert, aber Anzeige bestehender Shortcuts</string>
+    <string name="settings_customize_customShortcut_mode">Shortcuts</string>
+    <string name="settings_customize_customShortcut_info">Langes Drücken setzt Shortcut</string>
     <string name="ITEM_CANNOT_BE_SHORTCUT">Menüeintrag ist nicht shortcutfähig!</string>
     <string name="PLAY_RANDOM_FOLDER">Zufallswiedergabe</string>
     <string name="backward_seconds">Zurück Sekunden</string>
     <string name="forward_seconds">Vorwärts Sekunden</string>
+    <string name="RANDOM_PLAY_UNABLE">Fehler bei der Zufallswiedergabe</string>
+    <string name="RANDOM_PLAY_STARTED">Zufallswiedergabe gestartet</string>
 
 </resources>

--- a/Squeezer/src/main/res/values-fr/strings.xml
+++ b/Squeezer/src/main/res/values-fr/strings.xml
@@ -48,8 +48,6 @@
     <string name="settings_squeezeplayer_title">Démarrer SqueezePlayer</string>
     <string name="settings_squeezeplayer_summary">Cochez cette option pour vous assurer que SqueezePlayer est en cours d’exécution lorsque vous utilisez Squeezer.</string>
 
-    <string name="settings_category_ui">Interface</string>
-
     <string name="menu_item_disconnect">Déconnecter</string>
     <string name="menu_item_connect">Connexion</string>
     <string name="menu_item_poweron">Allumer \"%s\"</string>

--- a/Squeezer/src/main/res/values-nl/strings.xml
+++ b/Squeezer/src/main/res/values-nl/strings.xml
@@ -37,7 +37,6 @@
     <string name="settings_market_not_found">Kon Google Play niet starten. Is het wel geïnstalleerd?</string>
     <string name="settings_squeezeplayer_title">Start SqueezePlayer</string>
     <string name="settings_squeezeplayer_summary">Vink deze optie aan om er zeker van te zijn dat SqueezePlayer werkt bij gebruik van Squeezer</string>
-    <string name="settings_category_ui">Squeezer interface</string>
     <string name="menu_item_disconnect">Verbreek contact</string>
     <string name="menu_item_connect">Verbind</string>
     <string name="menu_item_poweron">Aanzetten \"%s\"</string>

--- a/Squeezer/src/main/res/values-tr/strings.xml
+++ b/Squeezer/src/main/res/values-tr/strings.xml
@@ -13,8 +13,7 @@
   <string name="settings_scrobble_on">Şarkı bilgisi Last.fm sitesine gönderildi</string>
   <string name="settings_market_not_found">Google Play başlatılamıyor, yüklü mü?</string>
   <string name="settings_squeezeplayer_title">SqueezePlayer\'ı başlat</string>
-  <string name="settings_category_ui">Squeezer arayüz</string>
-  <string name="menu_item_disconnect">Bağlantıyı Kes</string>
+    <string name="menu_item_disconnect">Bağlantıyı Kes</string>
   <string name="menu_item_connect">Bağlan</string>
   <string name="menu_item_poweron">\"%s\" aç</string>
   <string name="menu_item_poweroff">\"%s\" kapat</string>

--- a/Squeezer/src/main/res/values/strings.xml
+++ b/Squeezer/src/main/res/values/strings.xml
@@ -35,9 +35,9 @@
     <string name="settings_theme_title">Theme</string>
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_light_dark">Light, dark action bar</string>
-    <string name="settings_clear_current_playlist_confirmation">Ask for confirmation before clear current playlist</string>
-    <string name="settings_clear_current_playlist_confirmation_off">No confirmation dialog for \'Clear current playlist\' button</string>
-    <string name="settings_clear_current_playlist_confirmation_on">Use a confirmation dialog for \'Clear current playlist\' button</string>
+    <string name="settings_clear_current_playlist_confirmation">When clearing a playlist</string>
+    <string name="settings_clear_current_playlist_confirmation_off">do not ask for confirmation</string>
+    <string name="settings_clear_current_playlist_confirmation_on">ask for confirmation</string>
     <string name="settings_username_hint">User name (optional)</string>
     <string name="settings_password_hint">Password (optional)</string>
     <string name="settings_use_wake_on_lan">Wake up server (Wake-on-LAN)</string>
@@ -70,12 +70,12 @@
     <string name="settings_squeezeplayer_title">Start SqueezePlayer</string>
     <string name="settings_squeezeplayer_summary">Check this option to make sure SqueezePlayer is running, when using Squeezer</string>
 
-    <string name="settings_category_ui">Squeezer interface</string>
+    <string name="settings_category_ui">Shortcuts, Theme, etc.</string>
     <string name="settings_customize_home_menu_mode">Archive</string>
-    <string name="settings_customize_home_menu_info">The home screen as well as several submenus can be customized</string>
-    <string name="settings_customize_home_menu_archive">Long press an item archives/unarchives that item</string>
-    <string name="settings_customize_home_menu_disabled">Disable archive</string>
-    <string name="settings_customize_home_menu_locked">Disable long press, but leave archived items in the archive</string>
+    <string name="settings_customize_home_menu_info">Long press on suitable menu item puts it into an archive</string>
+    <string name="settings_customize_home_menu_archive">Enabled</string>
+    <string name="settings_customize_home_menu_disabled">Disabled</string>
+    <string name="settings_customize_home_menu_locked">Disabled, but keep archive</string>
 
     <string name="menu_item_disconnect">Disconnect</string>
     <string name="menu_item_connect">Connect</string>
@@ -394,25 +394,26 @@ of your accepting any such warranty or additional liability.&lt;/p&gt;</string>
     <string name="remote_preset5Description">Preset 5</string>
     <string name="remote_preset6Description">Preset 6</string>
     <string name="ARCHIVE_NODE">Archive</string>
-    <string name="MENU_ITEM_MOVED">Menu item moved</string>
+    <string name="MENU_ITEM_MOVED">Menu item (un)archived</string>
     <string name="MENU_IS_SUBMENU_IN_ARCHIVE">You are already in Archive!</string>
     <string name="ARCHIVE_CANNOT_BE_ARCHIVED">Archive cannot be archived!</string>
     <string name="ARCHIVE_NODE_REMOVED">Removed empty Archive</string>
     <string name="ITEM_CANNOT_BE_ARCHIVED">This item can not be archived!</string>
-    <string name="CUSTOM_SHORTCUT_REMOVED">Custom shortcut removed</string>
+    <string name="CUSTOM_SHORTCUT_REMOVED">Shortcut removed from home menu</string>
     <string name="ITEM_IS_ALREADY_A_SHORTCUT">Is already a shortcut!</string>
     <string name="ITEM_PUT_AS_SHORTCUT_ON_HOME_MENU">Shortcut put on home menu</string>
     <string name="ITEM_CAN_NOT_BE_SHORTCUT_OR_ARCHIVED">Can not be shortcut or archived!</string>
-    <string name="settings_custom_shortcut_enabled">Long press puts a suitable item on home screen</string>
-    <string name="settings_custom_shortcut_disabled">Custom shortcuts disabled</string>
-    <string name="settings_custom_shortcut_locked">Disable long press, but leave shortcuts on home screen.</string>
-    <string name="settings_customize_customShortcut_mode">Custom Shortcuts</string>
-    <string name="settings_customize_customShortcut_info">Long press puts shortcuts on top level menu.
-        (Changes in folders need renewed shortcuts.)</string>
+    <string name="settings_custom_shortcut_enabled">Enabled</string>
+    <string name="settings_custom_shortcut_disabled">Disabled</string>
+    <string name="settings_custom_shortcut_locked">Disabled, but show existing shortcuts.</string>
+    <string name="settings_customize_customShortcut_mode">Shortcuts</string>
+    <string name="settings_customize_customShortcut_info">Long press puts shortcuts in home menu.</string>
     <string name="ITEM_CANNOT_BE_SHORTCUT">Item can not be shortcut!</string>
     <string name="PLAY_RANDOM_FOLDER">Play random</string>
     <string name="backward" translatable="false">⏪ %d</string>
     <string name="forward" translatable="false">%d ⏩</string>
     <string name="backward_seconds">Backward seconds</string>
     <string name="forward_seconds">Forward seconds</string>
+    <string name="RANDOM_PLAY_UNABLE">Unable to start Random Play</string>
+    <string name="RANDOM_PLAY_STARTED">Random Play started</string>
 </resources>


### PR DESCRIPTION
The settings page is not very consistent at the moment. For example the sub menu name "squeezer-interface" makes no sense. I tried to make it better and deleted some translations in the process. 

We should maybe have a new sub menu called "long press items" with **shortcuts** and **archive** and rename the old "interface" to "others" (or similar) and just have **theme** and **playlist** in it. 