### PR TITLE
Implement common bluetooth commands

### DIFF
--- a/Squeezer/src/main/AndroidManifest.xml
+++ b/Squeezer/src/main/AndroidManifest.xml
@@ -126,7 +126,16 @@
 
         <service android:exported="false" android:label="Squeezer Service"
             android:name=".service.SqueezeService">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
         </service>
+
+        <receiver android:name="androidx.media.session.MediaButtonReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
 
         <activity
             android:name=".download.CancelDownloadsActivity"

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -667,6 +667,29 @@ public class SqueezeService extends Service {
             Notification notification = notificationData.builder.build();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                mMediaSession.setCallback(new MediaSessionCompat.Callback() {
+
+                    @Override
+                    public void onPlay() {
+                        squeezeService.play();
+                    }
+
+                    @Override
+                    public void onPause() {
+                        squeezeService.pause();
+                    }
+
+                    @Override
+                    public void onSkipToNext() {
+                        squeezeService.nextTrack();
+                    }
+
+                    @Override
+                    public void onSkipToPrevious() {
+                        squeezeService.previousTrack();
+                    }
+                });
+
                 final MediaMetadataCompat.Builder metaBuilder = new MediaMetadataCompat.Builder();
                 metaBuilder.putString(MediaMetadata.METADATA_KEY_ARTIST, notificationState.artistName);
                 metaBuilder.putString(MediaMetadata.METADATA_KEY_ALBUM, notificationState.albumName);


### PR DESCRIPTION
This could also solve potentially #742. Adds bluetooth commands for play/pause/prev/next as a side effect also enables volume control from bluetooth.


Tested on a Pebble that is connected via bluetooth