### PR TITLE
Add info level logging

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/PlayerState.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/PlayerState.java
@@ -74,7 +74,7 @@ public class PlayerState implements Parcelable {
         source.readStringList(mSyncSlaves);
         mPlayerSubscriptionType = PlayerSubscriptionType.valueOf(source.readString());
         prefs = source.readHashMap(getClass().getClassLoader());
-        mRandomPlaying =(source.readByte() == 1);
+        mPlayR =(source.readByte() == 1);
     }
 
     @Override
@@ -96,7 +96,7 @@ public class PlayerState implements Parcelable {
         dest.writeStringList(mSyncSlaves);
         dest.writeString(mPlayerSubscriptionType.name());
         dest.writeMap(prefs);
-        dest.writeByte(mRandomPlaying ? (byte) 1 : (byte) 0);
+        dest.writeByte(mPlayR ? (byte) 1 : (byte) 0);
     }
 
     @Override
@@ -143,7 +143,7 @@ public class PlayerState implements Parcelable {
     private double sleep;
 
     /** Is the player playing the tracks of a filesystem folder randomly (via context menu) **/
-    private boolean mRandomPlaying;
+    private boolean mPlayR;
 
     /** The player this player is synced to (null if none). */
     @Nullable
@@ -403,12 +403,12 @@ public class PlayerState implements Parcelable {
     }
 
     public boolean isRandomPlaying() {
-        return mRandomPlaying;
+        return mPlayR;
     }
 
     private static final String TAG = "PlayerState";
     public void setRandomPlaying(boolean b) {
-        mRandomPlaying = b;
+        mPlayR = b;
     }
 
     @StringDef({PLAY_STATE_PLAY, PLAY_STATE_PAUSE, PLAY_STATE_STOP})
@@ -436,7 +436,7 @@ public class PlayerState implements Parcelable {
                 ", mSyncMaster='" + mSyncMaster + '\'' +
                 ", mSyncSlaves=" + mSyncSlaves +
                 ", mPlayerSubscriptionType='" + mPlayerSubscriptionType + '\'' +
-                ", mRandomPlaying='" + mRandomPlaying + '\'' +
+                ", mPlayR='" + mPlayR + '\'' +
                 '}';
     }
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/RandomPlay.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/RandomPlay.java
@@ -62,10 +62,12 @@ public class RandomPlay {
     }
 
     void setNextTrack(String nextTrack) {
+        Log.i(TAG, String.format("Set nextTrack %s for Random Play on %s", nextTrack, player.getName()));
         this.nextTrack = nextTrack;
     }
 
     void setActiveFolderID(String folderID) {
+        Log.i(TAG, String.format("Set folder %s for Random Play on %s", folderID, player.getName()));
         this.activeFolderID = folderID;
     }
 
@@ -100,7 +102,11 @@ public class RandomPlay {
             if (!RandomPlay.this.firstFound) {
                 Set<String> loaded = new HashSet<>(rDelegate.getTracks(this.folderID));
                 loaded.removeAll(this.played);
-                playFirst(loaded);
+                if (loaded.size() > 0) {
+                    playFirst(loaded);
+                } else {
+                    Log.i(TAG, String.format("No unplayed tracks found yet for Random Play on %s.", player.getName()));
+                }
             }
 
             // All items loaded, if no unplayed are found, clear played
@@ -128,17 +134,14 @@ public class RandomPlay {
 
         // Get a track to play it, add it to played, save played to pref
         private void playFirst(Set<String> unplayed, String ignore) {
-            if (unplayed.size() > 0 ) {
-                String first = rDelegate.pickTrack(unplayed, ignore);
-                rDelegate.getSlimDelegate().command(rDelegate.getSlimDelegate().getActivePlayer())
-                        .cmd("playlistcontrol").param("cmd", "load")
-                        .param("play_index", "1").param("track_id", first).exec();
-                this.played.add(first);
-                RandomPlay.this.firstFound = true;
-                new Preferences(Squeezer.getContext()).saveRandomPlayed(folderID, played);
-            } else {
-                Log.e(TAG, "playFirst: Could not load first track.");
-            }
+            String first = rDelegate.pickTrack(unplayed, ignore);
+            rDelegate.getSlimDelegate().command(rDelegate.getSlimDelegate().getActivePlayer())
+                    .cmd("playlistcontrol").param("cmd", "load")
+                    .param("play_index", "1").param("track_id", first).exec();
+            this.played.add(first);
+            RandomPlay.this.firstFound = true;
+            new Preferences(Squeezer.getContext()).saveRandomPlayed(folderID, played);
+            Log.i(TAG, String.format("Saved first Random Play track to preferences for %s on %s", folderID, player.getName()));
         }
     }
 }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/RandomPlayDelegate.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/RandomPlayDelegate.java
@@ -20,6 +20,7 @@ public class RandomPlayDelegate {
     private SlimDelegate slimDelegate;
 
     static String pickTrack(Set<String> unplayed, String ignore) {
+        Log.i(TAG, String.format("Picking track randomly. Ignore '%s'.", ignore));
         Object[] stringArray = unplayed.toArray();
         String track = "";
         Random random = new Random();
@@ -31,18 +32,13 @@ public class RandomPlayDelegate {
     }
 
     void fillPlaylist(Set<String> unplayed, Player player, String ignore) {
-        if (unplayed.size() > 0 ) {
-            String nextTrack = pickTrack(unplayed, ignore);
-            slimDelegate.command(player).cmd("playlistcontrol")
-                    .param("cmd", "add").param("track_id", nextTrack).exec();
-
-            // Get the next track and set it for this player's instance.
-            // It will be loaded to be added to the played tracks when the next track begins
-            // to play (the track info does not contain the ID, so we have to do this).
-            slimDelegate.setNextTrack(player, nextTrack);
-        } else {
-            Log.e(TAG, "fillPlaylist: Could not find track and load it.");
-        }
+        String nextTrack = pickTrack(unplayed, ignore);
+        slimDelegate.command(player).cmd("playlistcontrol")
+                .param("cmd", "add").param("track_id", nextTrack).exec();
+        // Get the next track and set it for this player's instance.
+        // It will be loaded to be added to the played tracks when the next track begins
+        // to play (the track info does not contain the ID, so we have to do this).
+        slimDelegate.setNextTrack(player, nextTrack);
     }
 
     void addItems(String folderID, Set<String> folderTracks) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -762,13 +762,16 @@ public class SqueezeService extends Service {
 
         int number = playerState.getCurrentPlaylistTracksNum();
         int index = playerState.getCurrentPlaylistIndex();
+        Log.i(TAG, String.format("Random Play event for %s has number %d with index %d.", player.getName(), number, index));
         String nextTrack = randomPlay.getNextTrack();
         if (endRandomPlay(number, index)) {
-            Log.v(TAG, String.format("handleRandomOnEvent: End Random Play and reset '%s'.", player.getName()));
+            Log.i(TAG, String.format("End Random Play and reset '%s'.", player.getName()));
             randomPlay.reset(player);
         } else if (firstTwoTracksLoaded(number, index)) {
+            Log.i(TAG, String.format("Ignore event after Random Play initialization for player '%s'.", player.getName()));
             return;
         } else {
+            Log.i(TAG, String.format("Handle Random Play after event for player '%s'.", player.getName()));
             String folderID = randomPlay.getActiveFolderID();
             Set<String> tracks = randomPlay.getTracks(folderID);
             Set<String> played = preferences.loadRandomPlayed(folderID);
@@ -776,13 +779,18 @@ public class SqueezeService extends Service {
             preferences.saveRandomPlayed(folderID, played);
             Set<String> unplayed = new HashSet<>(tracks);
             if (played.size() == tracks.size()) {
-                Log.v(TAG, "handleRandomOnEvent: All played, clear played");
+                Log.i(TAG, String.format("All Random played from folder %s on player %s. Clear!", folderID, player.getName()));
                 played.clear();
                 preferences.saveRandomPlayed(folderID, played);
             } else {
                 unplayed.removeAll(played);
+                Log.i(TAG, String.format("Loaded %s unplayed tracks from folder %s for Random Play on player %s.", unplayed.size(), folderID, player.getName()));
             }
-            randomPlayDelegate.fillPlaylist(unplayed, player, nextTrack);
+            if (unplayed.size() > 0) {
+                randomPlayDelegate.fillPlaylist(unplayed, player, nextTrack);
+            } else {
+                Log.e(TAG, String.format("No unplayed tracks found for Random Play in folder %s on %s!", folderID, player.getName()));
+            }
         }
     }
 


### PR DESCRIPTION
- Rename PlayerState.mRandomPlaying 
- Add info level logging for the Random Play. 

Renaming mRandomPlaying is necessary so that running logcat with regex "Random" will not output posts from the EventBus.

Info Level loggin is necessary for debugging a Release version. 