### PR TITLE
Upgrading to Eventbus 3.1.0

### DIFF
--- a/Squeezer/build.gradle
+++ b/Squeezer/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.1'
 
     // EventBus, https://github.com/greenrobot/EventBus.
-    implementation 'de.greenrobot:eventbus:2.4.1'
+    implementation 'org.greenrobot:eventbus:3.1.0'
 
     // Changelogs, see https://github.com/cketti/ckChangeLog.
     implementation 'de.cketti.library.changelog:ckchangelog:1.2.0'

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/ConnectActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/ConnectActivity.java
@@ -26,6 +26,9 @@ import androidx.annotation.IntDef;
 
 import com.google.android.material.textfield.TextInputLayout;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -162,6 +165,7 @@ public class ConnectActivity extends BaseActivity {
         }
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         final Intent intent = new Intent(this, HomeActivity.class)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
@@ -56,6 +56,9 @@ import com.google.android.material.button.MaterialButton;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.slider.Slider;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -563,7 +566,7 @@ public class NowPlayingFragment extends Fragment {
      */
     private void maybeRegisterCallbacks(@NonNull ISqueezeService service) {
         if (!mRegisteredCallbacks) {
-            service.getEventBus().registerSticky(this);
+            service.getEventBus().register(this);
 
             mRegisteredCallbacks = true;
         }
@@ -873,6 +876,7 @@ public class NowPlayingFragment extends Fragment {
 
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ConnectionChanged event) {
         Log.d(TAG, "ConnectionChanged: " + event);
 
@@ -911,6 +915,7 @@ public class NowPlayingFragment extends Fragment {
      }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         // Event might arrive before this fragment has connected to the service (e.g.,
         // the activity connected before this fragment did).
@@ -946,12 +951,14 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(@SuppressWarnings("unused") RegisterSqueezeNetwork event) {
         // We're connected but the controller needs to register with the server
         JiveItemListActivity.register(mActivity);
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(MusicChanged event) {
         if (event.player.equals(mService.getActivePlayer())) {
             updateSongInfo(event.playerState);
@@ -959,11 +966,13 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PlayersChanged event) {
         updatePlayerDropDown(mService.getPlayers(), mService.getActivePlayer());
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PlayStatusChanged event) {
         if (event.player.equals(mService.getActivePlayer())) {
             updatePlayPauseIcon(event.playStatus);
@@ -971,6 +980,7 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PowerStatusChanged event) {
         if (event.player.equals(mService.getActivePlayer())) {
             updatePlayerMenuItems();
@@ -978,6 +988,7 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HomeMenuEvent event) {
         globalSearch = null;
         for (JiveItem menuItem : event.menuItems) {
@@ -992,6 +1003,7 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(RepeatStatusChanged event) {
         if (event.player.equals(mService.getActivePlayer())) {
             updateRepeatStatus(event.repeatStatus);
@@ -999,6 +1011,7 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ShuffleStatusChanged event) {
         if (event.player.equals(mService.getActivePlayer())) {
             updateShuffleStatus(event.shuffleStatus);
@@ -1006,6 +1019,7 @@ public class NowPlayingFragment extends Fragment {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(SongTimeChanged event) {
         if (event.player.equals(mService.getActivePlayer())) {
             updateTimeDisplayTo(event.currentPosition, event.duration);

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
@@ -75,6 +75,9 @@ import uk.org.ngo.squeezer.util.ImageFetcher;
 import uk.org.ngo.squeezer.util.SqueezePlayer;
 import uk.org.ngo.squeezer.util.ThemeManager;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 /**
  * Common base class for all activities in Squeezer.
  *
@@ -293,7 +296,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
      */
     private void maybeRegisterOnEventBus(@NonNull ISqueezeService service) {
         if (!mRegisteredOnEventBus) {
-            service.getEventBus().registerSticky(this);
+            service.getEventBus().register(this);
             mRegisteredOnEventBus = true;
         }
     }
@@ -365,6 +368,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
         return true;
     }
 
+    @Subscribe(sticky = true)
     public void onEvent(PlayerVolume event) {
         if (!mIgnoreVolumeChange && mService != null && event.player == mService.getActivePlayer()) {
             showVolumePanel();
@@ -397,6 +401,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
         showDisplayMessage(displayMessage);
     }
 
+    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(DisplayEvent displayEvent) {
         showDisplayMessage(displayEvent.message);
     }
@@ -446,6 +451,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
         }
     }
 
+    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEventMainThread(AlertEvent alert) {
         AlertEventDialog.show(getSupportFragmentManager(), alert.message.title, alert.message.text);
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseListActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseListActivity.java
@@ -24,6 +24,9 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.List;
 import java.util.Map;
 
@@ -72,6 +75,7 @@ public abstract class BaseListActivity<VH extends ItemViewHolder<T>, T extends I
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         super.onEventMainThread(event);
         if (!needPlayer() || getService().getActivePlayer() != null) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/ItemListActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/ItemListActivity.java
@@ -29,6 +29,9 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -266,6 +269,7 @@ public abstract class ItemListActivity extends BaseActivity {
      * Update the UI with the player change
      */
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ActivePlayerChanged event) {
         Log.i(TAG, "ActivePlayerChanged: " + event.player);
         supportInvalidateOptionsMenu();
@@ -282,6 +286,7 @@ public abstract class ItemListActivity extends BaseActivity {
      * Orders any pages requested before the handshake completed.
      */
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         // Order any pages that were requested before the handshake complete.
         while (!mOrderedPagesBeforeHandshake.empty()) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/homescreenwidgets/SqueezerHomeScreenWidget.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/homescreenwidgets/SqueezerHomeScreenWidget.java
@@ -13,6 +13,8 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 
+import org.greenrobot.eventbus.Subscribe;
+
 import uk.org.ngo.squeezer.service.ISqueezeService;
 import uk.org.ngo.squeezer.service.SqueezeService;
 import uk.org.ngo.squeezer.service.event.PlayersChanged;
@@ -49,7 +51,8 @@ public class SqueezerHomeScreenWidget extends AppWidgetProvider {
                     final ISqueezeService squeezeService = (ISqueezeService) service1;
 
                     // Wait for the PlayersChanged event
-                    squeezeService.getEventBus().registerSticky(new Object() {
+                    squeezeService.getEventBus().register(new Object() {
+                        @Subscribe(sticky = true)
                         public void onEvent(PlayersChanged event) {
                             squeezeService.getEventBus().unregister(this);
                             Log.i(SqueezerHomeScreenWidget.TAG, "Players ready, perform action");

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/homescreenwidgets/SqueezerRemoteControlPlayerSelectActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/homescreenwidgets/SqueezerRemoteControlPlayerSelectActivity.java
@@ -15,6 +15,9 @@ import androidx.appcompat.app.ActionBar;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -108,11 +111,12 @@ public class SqueezerRemoteControlPlayerSelectActivity extends BaseActivity {
         }
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         updatePlayerList();
     }
 
-
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PlayerStateChanged event) {
         updatePlayerList();
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmsActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmsActivity.java
@@ -31,6 +31,9 @@ import android.widget.TextView;
 import com.google.android.material.timepicker.MaterialTimePicker;
 import com.google.android.material.timepicker.TimeFormat;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -203,6 +206,7 @@ public class AlarmsActivity extends BaseListActivity<AlarmView, Alarm> implement
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(ActivePlayerChanged event) {
         super.onEventMainThread(event);
         mActivePlayer = event.player;

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/CurrentPlaylistActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/CurrentPlaylistActivity.java
@@ -33,6 +33,9 @@ import androidx.appcompat.app.ActionBar;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.recyclerview.widget.ItemTouchHelper;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.Map;
 
 import uk.org.ngo.squeezer.Preferences;
@@ -192,6 +195,7 @@ public class CurrentPlaylistActivity extends JiveItemListActivity implements Pla
         return getService().getCurrentPlaylist();
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(MusicChanged event) {
         if (getService() == null) {
             return;
@@ -204,6 +208,7 @@ public class CurrentPlaylistActivity extends JiveItemListActivity implements Pla
         }
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PlaylistChanged event) {
         if (getService() == null) {
             return;

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/GalleryActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/GalleryActivity.java
@@ -30,6 +30,9 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -65,6 +68,7 @@ public class GalleryActivity extends BaseActivity implements IServiceItemListCal
 
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         getService().pluginItems(action, this);
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/HomeActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/HomeActivity.java
@@ -28,6 +28,9 @@ import android.os.Bundle;
 import androidx.annotation.MainThread;
 import androidx.preference.PreferenceManager;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import uk.org.ngo.squeezer.Preferences;
 import uk.org.ngo.squeezer.R;
 import uk.org.ngo.squeezer.dialog.ChangeLogDialog;
@@ -56,6 +59,7 @@ public class HomeActivity extends HomeMenuActivity {
     }
 
     @MainThread
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         super.onEventMainThread(event);
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/HomeMenuActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/HomeMenuActivity.java
@@ -26,6 +26,8 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.greenrobot.eventbus.Subscribe;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -62,6 +64,7 @@ public class HomeMenuActivity extends JiveItemListActivity {
         new Preferences(this).setHomeMenuLayout(listLayout);
     }
 
+    @Subscribe(sticky = true)
     public void onEvent(HomeMenuEvent event) {
         runOnUiThread(() -> {
             if (parent.window == null) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/JiveItemListActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/JiveItemListActivity.java
@@ -323,6 +323,7 @@ public class JiveItemListActivity extends BaseListActivity<ItemViewHolder<JiveIt
         }
     }
 
+    // TODO: Adding Annotation will result in crash - @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         super.onEventMainThread(event);
         if (parent != null && parent.hasSubItems()) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/PlayerListActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/PlayerListActivity.java
@@ -23,6 +23,9 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -83,7 +86,6 @@ public class PlayerListActivity extends ItemListActivity implements
     protected boolean needPlayer() {
         return false;
     }
-
 
 
     public void onEventMainThread(PlayerVolume event) {
@@ -216,11 +218,13 @@ public class PlayerListActivity extends ItemListActivity implements
         // initially connected to the server.
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(HandshakeComplete event) {
         super.onEventMainThread(event);
         updateAndExpandPlayerList();
     }
 
+    @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEventMainThread(PlayerStateChanged event) {
         if (mTrackingTouch == null) {
             updateAndExpandPlayerList();

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/BaseClient.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/BaseClient.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 import uk.org.ngo.squeezer.R;
 import uk.org.ngo.squeezer.Squeezer;
 import uk.org.ngo.squeezer.Util;

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/CometClient.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/CometClient.java
@@ -47,7 +47,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+
 import uk.org.ngo.squeezer.Preferences;
 import uk.org.ngo.squeezer.Util;
 import uk.org.ngo.squeezer.model.AlertWindow;
@@ -590,6 +592,7 @@ class CometClient extends BaseClient {
         }
     }
 
+    @Subscribe
     public void onEvent(@SuppressWarnings("unused") HandshakeComplete event) {
         mBackgroundHandler.removeMessages(MSG_HANDSHAKE_TIMEOUT);
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ConnectionState.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ConnectionState.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 import uk.org.ngo.squeezer.Util;
 import uk.org.ngo.squeezer.model.CustomJiveItemHandling;
 import uk.org.ngo.squeezer.model.MenuStatusMessage;

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/HomeMenuHandling.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/HomeMenuHandling.java
@@ -13,7 +13,7 @@ import java.util.Vector;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 import uk.org.ngo.squeezer.model.JiveItem;
 import uk.org.ngo.squeezer.model.MenuStatusMessage;
 import uk.org.ngo.squeezer.service.event.HomeMenuEvent;

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ISqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ISqueezeService.java
@@ -22,7 +22,7 @@ import androidx.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 import uk.org.ngo.squeezer.itemlist.IServiceItemListCallback;
 import uk.org.ngo.squeezer.model.Action;
 import uk.org.ngo.squeezer.model.Alarm;

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SlimDelegate.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SlimDelegate.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import de.greenrobot.event.EventBus;
+import org.greenrobot.eventbus.EventBus;
 import uk.org.ngo.squeezer.itemlist.IServiceItemListCallback;
 import uk.org.ngo.squeezer.model.JiveItem;
 import uk.org.ngo.squeezer.model.Player;


### PR DESCRIPTION
This is working but has some issues:

- There was one class which had a higher priority. I added this priority to the methods but I did not grasp why it has to be done or if it is usefull the way I did it.
- I added one TODO for an issue where I could not add the annotation because it resulted in the app crashing upon start.
- Moving the slider for a song forward or backward will result in the song playing correctly from the new position. But the view will revert to the old time stamp for a short instance before it will show the valid time. I think this was already an issue before the upgrade (or in the past) and it could be related to a sticky event that should be deleted. Or we might remove the stickyness. Something similar is also visible when starting a track. The indicator will move forward and then backward again for a second.

I would rather merge this fast and fix (upcoming) issues later.