### PR TITLE
WoL: LAN broadcast address

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/util/SendWakeOnLan.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/util/SendWakeOnLan.java
@@ -20,7 +20,7 @@ public class SendWakeOnLan {
      * UDP port to broadcast WOL message to.
      */
     private static final int WOL_PORT = 9;
-    public static final String BROADCAST_ADDRESS = "192.168.0.255";
+    public static final String BROADCAST_ADDRESS = "255.255.255.255";
 
     public static void sendWakeOnLan(byte[] mac) {
 


### PR DESCRIPTION
Hi kaalholst,

Noticed WoL didn't quite function in 2.3.0. Compared magic packet generated by Squeezer versus other packages, and the difference was the destination IP of 192.168.0.255. That could be non-local for some home networks. Other packages use 255.255.255.255 for it to work against devices on directly connected networks.
tested against latest develop branch in https://github.com/kaaholst/android-squeezer.git
Cheers
Matt