### PR TITLE
Add display options for wall-mounted tablet operation

### DIFF
--- a/Squeezer/src/main/AndroidManifest.xml
+++ b/Squeezer/src/main/AndroidManifest.xml
@@ -132,6 +132,11 @@
             android:theme="@style/Theme.MaterialComponents.NoActionBar">
         </activity>
 
+        <activity
+            android:name=".screensaver.BlackScreensaver"
+            android:theme="@style/Theme.MaterialComponents.NoActionBar">
+        </activity>
+
         <service android:exported="false" android:label="Squeezer Service"
             android:foregroundServiceType="mediaPlayback"
             android:name=".service.SqueezeService">

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
@@ -527,6 +527,8 @@ public class NowPlayingFragment extends Fragment  implements OnCrollerChangeList
     @UiThread
     private void updatePlayPauseIcon(@PlayerState.PlayState String playStatus) {
         playPauseButton.setIconResource((PlayerState.PLAY_STATE_PLAY.equals(playStatus)) ? R.drawable.ic_action_pause : R.drawable.ic_action_play);
+        // send a signal to the screensaver timers to start or stop count down
+        mActivity.setNotplayingTimer((PlayerState.PLAY_STATE_PLAY.equals(playStatus)) ? false : true);
     }
 
     @UiThread

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
@@ -172,6 +172,9 @@ public final class Preferences {
     // Preferred UI theme.
     static final String KEY_ON_THEME_SELECT_ACTION = "squeezer.theme";
 
+    // Behavior of NowPlaying screen
+    public static final String KEY_ON_NOW_PLAYING_SELECT = "squeezer.always_to_nowplaying";
+
     // Screensaver
     public static final String KEY_SCREENSAVER = "squeezer.screensaver";
 
@@ -534,6 +537,14 @@ public final class Preferences {
 
     public void setTheme(ThemeManager.Theme theme) {
         sharedPreferences.edit().putString(Preferences.KEY_ON_THEME_SELECT_ACTION, theme.name()).apply();
+    }
+
+    public boolean isNowPlayingSwitching() {
+        return sharedPreferences.getBoolean(KEY_ON_NOW_PLAYING_SELECT, false);
+    }
+
+    public void setNowPlayingSwitching(boolean b) {
+        sharedPreferences.edit().putBoolean(Preferences.KEY_ON_NOW_PLAYING_SELECT, b).apply();
     }
 
     public ScreensaverMode getScreensaverMode() {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
@@ -903,9 +903,12 @@ public final class Preferences {
     }
 
     public enum ScreensaverMode implements EnumWithText {
-        OFF(R.string.settings_screensaver_off),
         ON(R.string.settings_screensaver_on),
-        CLOCK(R.string.settings_screensaver_clock);
+        OFF(R.string.settings_screensaver_off),
+        OFF_NOTPLAYING(R.string.settings_screensaver_off_whenNotPlaying),
+        CLOCK(R.string.settings_screensaver_clock),
+        CLOCK_NOTPLAYING(R.string.settings_screensaver_clock_whenNotPlaying);
+
 
         private final int labelId;
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/SettingsFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/SettingsFragment.java
@@ -185,6 +185,9 @@ public class SettingsFragment  extends PreferenceFragmentCompat implements
         }
         onSelectThemePref.setOnPreferenceChangeListener(this);
 
+        final SwitchPreferenceCompat alwaysSwitchToNowPlaying = findPreference(Preferences.KEY_ON_NOW_PLAYING_SELECT);
+        alwaysSwitchToNowPlaying.setChecked(preferences.isNowPlayingSwitching());
+
         ListPreference screensaverPref = findPreference(Preferences.KEY_SCREENSAVER);
         fillEnumPreference(screensaverPref, Preferences.ScreensaverMode.class, preferences.getScreensaverMode());
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
@@ -161,7 +161,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
         }
     }
 
-    private static final int INACTIVITY_TIME = 1 * 60 * 1000;
+    private static final int INACTIVITY_TIME = 5 * 60 * 1000;
     Handler inactivityHandler = null;
     Runnable inactivityAction;
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/framework/BaseActivity.java
@@ -253,7 +253,7 @@ public abstract class BaseActivity extends AppCompatActivity implements Download
 
         setInactivityTimer(true);
 
-         // If SqueezePlayer is installed, start it
+        // If SqueezePlayer is installed, start it
         squeezePlayer = SqueezePlayer.maybeStartControllingSqueezePlayer(this);
 
         // Ensure that any image fetching tasks started by this activity do not finish prematurely.

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/JiveItemListActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/JiveItemListActivity.java
@@ -463,6 +463,11 @@ public class JiveItemListActivity extends BaseListActivity<ItemViewHolder<JiveIt
             switch (nextWindow.nextWindow) {
                 case nowPlaying:
                     // Do nothing as now playing is always available in Squeezer (maybe toast the action)
+                    // only if set by special preference
+                    Preferences preferences = Squeezer.getPreferences();
+                    if (preferences.isNowPlayingSwitching()) {
+                        NowPlayingActivity.show(this);
+                    }
                     break;
                 case playlist:
                     CurrentPlaylistActivity.show(this);

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/screensaver/BlackScreensaver.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/screensaver/BlackScreensaver.java
@@ -1,0 +1,31 @@
+package uk.org.ngo.squeezer.screensaver;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Bundle;
+import android.view.WindowManager;
+
+
+public class BlackScreensaver extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        WindowManager.LayoutParams params = getWindow().getAttributes();
+        params.screenBrightness = 0;
+        params.flags &= ~ WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
+        getWindow().setAttributes(params);
+
+    }
+
+    @Override
+    public void onUserInteraction() {
+        super.onUserInteraction();
+        WindowManager.LayoutParams params = getWindow().getAttributes();
+        params.screenBrightness = -1;
+        params.flags |= WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
+        finish();
+    }
+
+}

--- a/Squeezer/src/main/res/values-de/strings.xml
+++ b/Squeezer/src/main/res/values-de/strings.xml
@@ -257,9 +257,11 @@
     <string name="RANDOM_PLAY_STARTED">Zufallswiedergabe gestartet</string>
     <string name="minutes">Minuten</string>
     <string name="settings_screensaver_title">Display aktiviert lassen</string>
-    <string name="settings_screensaver_off">Nein</string>
-    <string name="settings_screensaver_on">Ja</string>
-    <string name="settings_screensaver_clock">Uhr zeigen bei Inaktivität</string>
+    <string name="settings_screensaver_off">bei AktivitÃ¤t</string>
+    <string name="settings_screensaver_on">Immer</string>
+    <string name="settings_screensaver_clock">bei AktivitÃ¤t, dann Uhr zeigen</string>
+    <string name="settings_screensaver_clock_whenNotPlaying">während abgespielt wird, dann Uhr zeigen</string>
+    <string name="settings_screensaver_off_whenNotPlaying">während abgespielt wird</string>
     <string name="settings_switch_to_nowplaying_title">NowPlaying-Bildschirm Verhalten</string>
     <string name="settings_switch_to_nowplaying_on">Immer auf NowPlaying wechseln wenn ein Item ausgewählt wurde</string>
     <string name="settings_switch_to_nowplaying_off">Bildschirm nicht automatisch wechseln</string>

--- a/Squeezer/src/main/res/values-de/strings.xml
+++ b/Squeezer/src/main/res/values-de/strings.xml
@@ -260,6 +260,9 @@
     <string name="settings_screensaver_off">Nein</string>
     <string name="settings_screensaver_on">Ja</string>
     <string name="settings_screensaver_clock">Uhr zeigen bei Inaktivität</string>
+    <string name="settings_switch_to_nowplaying_title">NowPlaying-Bildschirm Verhalten</string>
+    <string name="settings_switch_to_nowplaying_on">Immer auf NowPlaying wechseln wenn ein Item ausgewählt wurde</string>
+    <string name="settings_switch_to_nowplaying_off">Bildschirm nicht automatisch wechseln</string>
     <string name="settings_volume_title">Einstellungen für Lautstärkeregelung</string>
     <string name="settings_restore_after_call">Nach Beendigung wieder starten</string>
     <string name="call_state_permission_message">Bei einem Anruf kann Squeezer die Wiedergabe pausieren.</string>

--- a/Squeezer/src/main/res/values-fr/strings.xml
+++ b/Squeezer/src/main/res/values-fr/strings.xml
@@ -42,6 +42,9 @@
     <string name="settings_fadeinsecs_title">Temps d\'ouverture en fondu</string>
     <string name="settings_fadeinsecs_summary">Entrez la durée d\'ouverture en fondu, en secondes, quand en pause. Entrez 0 pour désactiver l\'ouverture en fondu.</string>
 
+    <string name="settings_switch_to_nowplaying_title">Comportement du vue NowPlaying</string>
+    <string name="settings_switch_to_nowplaying_on">Toujours alterner à la vue NowPlaying quand on a choisi un élément</string>
+    <string name="settings_switch_to_nowplaying_off">Pas alterner la vue</string>
     <string name="settings_scrobble_title">Faire du scrobble par Last.fm</string>
     <string name="settings_scrobble_on">Les informations sur le morceau sont envoyées à Last.fm</string>
     <string name="settings_scrobble_off">Les informations sur le morceau ne sont pas envoyées à Last.fm</string>

--- a/Squeezer/src/main/res/values/strings.xml
+++ b/Squeezer/src/main/res/values/strings.xml
@@ -39,9 +39,11 @@
     <string name="settings_theme_dark">Dark</string>
     <string name="settings_theme_light_dark">Light, dark action bar</string>
     <string name="settings_screensaver_title">Keep screen on</string>
-    <string name="settings_screensaver_off">No</string>
-    <string name="settings_screensaver_on">Yes</string>
-    <string name="settings_screensaver_clock">Show clock when idle</string>
+    <string name="settings_screensaver_off">while active</string>
+    <string name="settings_screensaver_on">always</string>
+    <string name="settings_screensaver_clock">while active, then show clock</string>
+    <string name="settings_screensaver_clock_whenNotPlaying">while playing, then show clock</string>
+    <string name="settings_screensaver_off_whenNotPlaying">while playing</string>
     <string name="settings_switch_to_nowplaying_title">NowPlaying screen behavior</string>
     <string name="settings_switch_to_nowplaying_on">Always switch to NowPlaying screen when item has been chosen</string>
     <string name="settings_switch_to_nowplaying_off">Remain on current screen</string>

--- a/Squeezer/src/main/res/values/strings.xml
+++ b/Squeezer/src/main/res/values/strings.xml
@@ -42,6 +42,9 @@
     <string name="settings_screensaver_off">No</string>
     <string name="settings_screensaver_on">Yes</string>
     <string name="settings_screensaver_clock">Show clock when idle</string>
+    <string name="settings_switch_to_nowplaying_title">NowPlaying screen behavior</string>
+    <string name="settings_switch_to_nowplaying_on">Always switch to NowPlaying screen when item has been chosen</string>
+    <string name="settings_switch_to_nowplaying_off">Remain on current screen</string>
     <string name="settings_add_composer_line">Show composer</string>
     <string name="settings_band_instead_album">Classical music information</string>
     <string name="settings_add_conductor_line">Show band and conductor</string>

--- a/Squeezer/src/main/res/xml/preferences.xml
+++ b/Squeezer/src/main/res/xml/preferences.xml
@@ -40,6 +40,12 @@
             android:title="@string/settings_theme_title"
             android:summary="%s"/>
 
+        <SwitchPreferenceCompat
+            android:key="squeezer.always_to_nowplaying"
+            android:summaryOff="@string/settings_switch_to_nowplaying_off"
+            android:summaryOn="@string/settings_switch_to_nowplaying_on"
+            android:title="@string/settings_switch_to_nowplaying_title"/>
+
         <ListPreference
             android:key="squeezer.screensaver"
             android:title="@string/settings_screensaver_title"


### PR DESCRIPTION
- New options for screensaver in global settings (in addition to the existing ones) to keep screen on as long as music is played. This can be useful if the app is running on a wall-mounted tablet where somebody wants to see always what is currently playing.
  - Display clock when not playing
  - Display black screen when not playing, let then android system determine when the screen is completely off / locked.
- New option in global settings to always switch to NowPlaying view after an item has been chosen in ListView. This also supports wall-mounted operation: User wants to choose some music and then walk away.

Please have a special look on the BlackScreenSaver class, I am not completely sure whether the approach to make the screen black is robust, also against future Android versions (tested successfully, but only on Android 10).