### PR TITLE
add Preset editor

### DIFF
--- a/Squeezer/build.gradle
+++ b/Squeezer/build.gradle
@@ -159,6 +159,7 @@ slimstrings {
             'ALARM_DELETE',
             'ALARM_DELETING',
             'ALARM_ALL_ALARMS',
+            'PRESETS_NOT_DEFINED',
             'MORE',
             'SETTINGS',
             'SCREEN_SETTINGS',

--- a/Squeezer/src/main/AndroidManifest.xml
+++ b/Squeezer/src/main/AndroidManifest.xml
@@ -132,6 +132,11 @@
         </activity>
 
         <activity android:exported="true"
+            android:name=".itemlist.PresetsActivity"
+            android:parentActivityName=".itemlist.HomeActivity">
+        </activity>
+
+        <activity android:exported="true"
             android:name=".itemlist.CurrentPlaylistActivity"
             android:parentActivityName=".NowPlayingActivity">
         </activity>

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/NowPlayingFragment.java
@@ -75,6 +75,7 @@ import uk.org.ngo.squeezer.itemlist.IServiceItemListCallback;
 import uk.org.ngo.squeezer.itemlist.JiveItemListActivity;
 import uk.org.ngo.squeezer.itemlist.PlayerListActivity;
 import uk.org.ngo.squeezer.itemlist.PlayerViewLogic;
+import uk.org.ngo.squeezer.itemlist.PresetsActivity;
 import uk.org.ngo.squeezer.model.CurrentTrack;
 import uk.org.ngo.squeezer.model.Input;
 import uk.org.ngo.squeezer.model.JiveItem;
@@ -154,6 +155,8 @@ public class NowPlayingFragment extends Fragment  implements CallStateDialog.Cal
     private MenuItem menuItemCancelSleep;
 
     private MenuItem menuItemAlarm;
+
+    private MenuItem menuItemPresets;
 
     private MaterialButton playPauseButton;
 
@@ -946,6 +949,7 @@ public class NowPlayingFragment extends Fragment  implements CallStateDialog.Cal
 
         menuItemPlayers = menu.findItem(R.id.menu_item_players);
         menuItemAlarm = menu.findItem(R.id.menu_item_alarm);
+        menuItemPresets = menu.findItem(R.id.menu_item_presets);
     }
 
     /**
@@ -972,6 +976,7 @@ public class NowPlayingFragment extends Fragment  implements CallStateDialog.Cal
             menuItemPlaylist.setVisible(haveConnectedPlayers);
             menuItemPlayers.setVisible(haveConnectedPlayers);
             menuItemAlarm.setVisible(haveConnectedPlayers);
+            menuItemPresets.setVisible(haveConnectedPlayers);
             menuItemSleep.setVisible(haveConnectedPlayers);
 
             // Don't show the item to go to current playlist if in CurrentPlaylistActivity.
@@ -987,6 +992,11 @@ public class NowPlayingFragment extends Fragment  implements CallStateDialog.Cal
             // Don't show the item to go to alarms if in AlarmsActivity.
             if (mActivity instanceof AlarmsActivity) {
                 menuItemAlarm.setVisible(false);
+            }
+
+            // Don't show the item to go to presets if in PresetsActivity.
+            if (mActivity instanceof PresetsActivity) {
+                menuItemPresets.setVisible(false);
             }
         }
 
@@ -1026,6 +1036,9 @@ public class NowPlayingFragment extends Fragment  implements CallStateDialog.Cal
             return true;
         } else if (itemId == R.id.menu_item_alarm) {
             AlarmsActivity.show(mActivity);
+            return true;
+        } else if (itemId == R.id.menu_item_presets) {
+            PresetsActivity.show(mActivity);
             return true;
         } else if (itemId == R.id.menu_item_about) {
             new AboutDialog().show(getParentFragmentManager(), "AboutDialog");

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmPlayListCategoryAdapter.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmPlayListCategoryAdapter.java
@@ -18,7 +18,6 @@ import java.util.List;
 import uk.org.ngo.squeezer.R;
 import uk.org.ngo.squeezer.framework.BaseActivity;
 import uk.org.ngo.squeezer.framework.ItemViewHolder;
-import uk.org.ngo.squeezer.model.Alarm;
 import uk.org.ngo.squeezer.model.AlarmPlaylist;
 import uk.org.ngo.squeezer.model.Item;
 
@@ -27,7 +26,7 @@ public class AlarmPlayListCategoryAdapter extends RecyclerView.Adapter<AlarmPlay
     private final List<ChildAdapterHolder> childAdapterHolders = new ArrayList<>();
     private final List<PlayListCategory> categories;
 
-    public AlarmPlayListCategoryAdapter(BaseActivity activity, Alarm alarm, List<AlarmPlaylist> alarmPlaylists) {
+    public AlarmPlayListCategoryAdapter(BaseActivity activity, String currentUrl, List<AlarmPlaylist> alarmPlaylists) {
         this.activity = activity;
         PlayListCategory currentCategory = null;
         categories = new ArrayList<>();
@@ -35,10 +34,10 @@ public class AlarmPlayListCategoryAdapter extends RecyclerView.Adapter<AlarmPlay
             AlarmPlaylist alarmPlaylist = alarmPlaylists.get(position);
             if (currentCategory == null || !alarmPlaylist.getCategory().equals(currentCategory.category)) {
                 categories.add(currentCategory = new PlayListCategory(alarmPlaylist.getCategory()));
-                childAdapterHolders.add(new ChildAdapterHolder(activity, alarm));
+                childAdapterHolders.add(new ChildAdapterHolder(activity, currentUrl));
             }
             currentCategory.playlists.add(alarmPlaylist);
-            if (alarmPlaylist.getId() != null && alarmPlaylist.getId().equals(alarm.getPlayListId())) {
+            if (alarmPlaylist.getId() != null && alarmPlaylist.getId().equals(currentUrl)) {
                 childAdapterHolders.get(childAdapterHolders.size()-1).visible = true;
             }
         }
@@ -105,8 +104,8 @@ public class AlarmPlayListCategoryAdapter extends RecyclerView.Adapter<AlarmPlay
         boolean visible = false;
         private final AlarmPlaylistAdapter adapter;
 
-        public ChildAdapterHolder(BaseActivity activity, Alarm alarm) {
-            adapter = new AlarmPlaylistAdapter(activity, alarm);
+        public ChildAdapterHolder(BaseActivity activity, String currentUrl) {
+            adapter = new AlarmPlaylistAdapter(activity, currentUrl);
         }
     }
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmPlaylistActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmPlaylistActivity.java
@@ -13,24 +13,23 @@ import java.util.List;
 
 import uk.org.ngo.squeezer.R;
 import uk.org.ngo.squeezer.framework.BaseActivity;
-import uk.org.ngo.squeezer.model.Alarm;
 import uk.org.ngo.squeezer.model.AlarmPlaylist;
 import uk.org.ngo.squeezer.widget.ViewUtilities;
 
 public class AlarmPlaylistActivity extends BaseActivity {
     static final int GET_ALARM_PLAYLIST = 1;
     static final String ALARM_PLAYLIST = "ALARM_PLAYLIST";
-    private static final String ALARM = "alarm";
+    private static final String CURRENT_URL = "currentUrl";
     private static final String PLAYLISTS = "playlists";
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Alarm alarm = getIntent().getParcelableExtra(ALARM);
+        String currentUrl = getIntent().getStringExtra(CURRENT_URL);
         List<AlarmPlaylist> alarmPlaylists = getIntent().getParcelableArrayListExtra(PLAYLISTS);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.list_activity_layout);
 
-        AlarmPlayListCategoryAdapter adapter = new AlarmPlayListCategoryAdapter(this, alarm, alarmPlaylists);
+        AlarmPlayListCategoryAdapter adapter = new AlarmPlayListCategoryAdapter(this, currentUrl, alarmPlaylists);
         RecyclerView listView = requireView(R.id.item_list);
         listView.setAdapter(adapter);
         listView.setLayoutManager(new LinearLayoutManager(this));
@@ -45,9 +44,9 @@ public class AlarmPlaylistActivity extends BaseActivity {
         }
     }
 
-    public static void show(Activity context, Alarm alarm, List<AlarmPlaylist> alarmPlaylists) {
+    public static void show(Activity context, String currentUrl, List<AlarmPlaylist> alarmPlaylists) {
         Intent intent = new Intent(context, AlarmPlaylistActivity.class);
-        intent.putExtra(ALARM, alarm);
+        intent.putExtra(CURRENT_URL, currentUrl);
         intent.putParcelableArrayListExtra(PLAYLISTS, new ArrayList<>(alarmPlaylists));
         context.startActivityForResult(intent, GET_ALARM_PLAYLIST);
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmPlaylistAdapter.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmPlaylistAdapter.java
@@ -16,17 +16,16 @@ import java.util.List;
 import uk.org.ngo.squeezer.R;
 import uk.org.ngo.squeezer.framework.BaseActivity;
 import uk.org.ngo.squeezer.framework.ItemViewHolder;
-import uk.org.ngo.squeezer.model.Alarm;
 import uk.org.ngo.squeezer.model.AlarmPlaylist;
 
 class AlarmPlaylistAdapter extends RecyclerView.Adapter<ItemViewHolder<AlarmPlaylist>> {
     private final BaseActivity activity;
-    private final Alarm alarm;
+    private final String currentUrl;
     private List<AlarmPlaylist> playlists;
 
-    public AlarmPlaylistAdapter(BaseActivity activity, Alarm alarm) {
+    public AlarmPlaylistAdapter(BaseActivity activity, String currentUrl) {
         this.activity = activity;
-        this.alarm = alarm;
+        this.currentUrl = currentUrl;
     }
 
     @Override
@@ -60,7 +59,7 @@ class AlarmPlaylistAdapter extends RecyclerView.Adapter<ItemViewHolder<AlarmPlay
         public void bindView(AlarmPlaylist item) {
             super.bindView(item);
             ((TextView) itemView).setText(item.getName());
-            @AttrRes int background = (item.getId().equals(alarm.getPlayListId())) ? R.attr.currentTrackBackground : R.attr.selectableItemBackground;
+            @AttrRes int background = (item.getId().equals(currentUrl)) ? R.attr.currentTrackBackground : R.attr.selectableItemBackground;
             itemView.setBackgroundResource(getActivity().getAttributeValue(background));
             itemView.setOnClickListener(v -> {
                 Intent intent = new Intent().putExtra(AlarmPlaylistActivity.ALARM_PLAYLIST, item);

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmsActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/AlarmsActivity.java
@@ -101,7 +101,7 @@ public class AlarmsActivity extends ItemListActivity<AlarmView, Alarm> implement
 
     void selectAlarmPlaylist(int position) {
         currentAlarm = position;
-        AlarmPlaylistActivity.show(this, getItemAdapter().getItem(position), getAlarmPlaylists());
+        AlarmPlaylistActivity.show(this, getItemAdapter().getItem(position).getPlayListId(), getAlarmPlaylists());
     }
 
     @Override

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/JiveItemView.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/JiveItemView.java
@@ -169,6 +169,11 @@ public class JiveItemView extends ViewParamItemView<JiveItem> {
     }
 
     public void onItemSelected() {
+        if (JiveItem.SETTINGS_PRESETS.getId().equals(item.getId())) {
+            PresetsActivity.show(getActivity());
+            return;
+        }
+
         Action.JsonAction action = (item.goAction != null && item.goAction.action != null) ? item.goAction.action : null;
         Action.NextWindow nextWindow = (action != null ? action.nextWindow : item.nextWindow);
         if (item.checkbox != null) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/PresetsActivity.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/itemlist/PresetsActivity.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2026 Thomas Malcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.org.ngo.squeezer.itemlist;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.ActionBar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import uk.org.ngo.squeezer.R;
+import uk.org.ngo.squeezer.framework.BaseActivity;
+import uk.org.ngo.squeezer.model.AlarmPlaylist;
+import uk.org.ngo.squeezer.model.Player;
+import uk.org.ngo.squeezer.model.Preset;
+import uk.org.ngo.squeezer.service.IRButton;
+import uk.org.ngo.squeezer.service.ISqueezeService;
+import uk.org.ngo.squeezer.service.event.ActivePlayerChanged;
+import uk.org.ngo.squeezer.service.event.PlayerStateChanged;
+import uk.org.ngo.squeezer.widget.ViewUtilities;
+
+/**
+ * Edit the presets of the active player, i.e. assign favorites to the preset buttons of the
+ * player, like the presets editor of the LMS web interface.
+ */
+public class PresetsActivity extends BaseActivity {
+    /** The number of preset buttons on the players. */
+    private static final int NUM_PRESETS = IRButton.values().length;
+
+    private static final String CURRENT_PRESET = "currentPreset";
+
+    /** The most recent active player. */
+    private Player activePlayer;
+
+    /** The items available for the presets, from the "alarm playlists" command. */
+    private final List<AlarmPlaylist> alarmPlaylists = new ArrayList<>();
+
+    /** The preset slot (0-based) a new item is currently selected for. */
+    private int currentPreset;
+
+    private PresetsAdapter adapter;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.list_activity_layout);
+
+        if (savedInstanceState != null) {
+            currentPreset = savedInstanceState.getInt(CURRENT_PRESET);
+        }
+
+        adapter = new PresetsAdapter();
+        RecyclerView listView = requireView(R.id.item_list);
+        listView.setAdapter(adapter);
+        listView.setLayoutManager(new LinearLayoutManager(this));
+
+        setSupportActionBar(requireView(R.id.toolbar));
+        ViewUtilities.setInsetsListener(requireView(R.id.toolbar), true, false, false);
+        ViewUtilities.setInsetsListener(listView, false, true, false);
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setTitle(R.string.menu_item_presets);
+        }
+    }
+
+    @Override
+    protected void onServiceConnected(@NonNull ISqueezeService service) {
+        super.onServiceConnected(service);
+        repository().observe(this, this::onPlayerStateChanged);
+        repository().observe(this, (ActivePlayerChanged event) -> {
+            activePlayer = event.player;
+            adapter.notifyDataSetChanged();
+        });
+        activePlayer = service.getActivePlayer();
+        service.alarmPlaylists(alarmPlaylistsCallback);
+        adapter.notifyDataSetChanged();
+    }
+
+    private void onPlayerStateChanged(PlayerStateChanged event) {
+        if (event.player.equals(activePlayer)) {
+            adapter.notifyDataSetChanged();
+        }
+    }
+
+    private final IServiceItemListCallback<AlarmPlaylist> alarmPlaylistsCallback = new IServiceItemListCallback<>() {
+        private final List<AlarmPlaylist> items = new ArrayList<>();
+
+        @Override
+        public void onItemsReceived(final int count, final int start, Map<String, Object> parameters, final List<AlarmPlaylist> newItems, Class<AlarmPlaylist> dataType) {
+            runOnUiThread(() -> {
+                if (start == 0) {
+                    items.clear();
+                }
+
+                // A preset needs an URL, so skip items without, e.g. "Use current playlist",
+                // like the presets editor of the LMS web interface.
+                newItems.stream().filter(item -> !item.getId().isEmpty()).forEach(items::add);
+                if (start + newItems.size() >= count) {
+                    alarmPlaylists.clear();
+                    alarmPlaylists.addAll(items);
+                }
+            });
+        }
+
+        @Override
+        public Object getClient() {
+            return PresetsActivity.this;
+        }
+    };
+
+    /** @return The preset assigned to the supplied slot (0-based), null if unassigned. */
+    private Preset getPreset(int position) {
+        List<Preset> presets = (activePlayer != null) ? activePlayer.getPlayerState().getPresets() : null;
+        if (presets == null || position >= presets.size()) {
+            return null;
+        }
+
+        Preset preset = presets.get(position);
+        return preset.isSet() ? preset : null;
+    }
+
+    void selectPreset(int position) {
+        currentPreset = position;
+        Preset preset = getPreset(position);
+        AlarmPlaylistActivity.show(this, (preset != null) ? preset.url : null, alarmPlaylists);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == AlarmPlaylistActivity.GET_ALARM_PLAYLIST && resultCode == Activity.RESULT_OK) {
+            AlarmPlaylist alarmPlaylist = Objects.requireNonNull(data.getParcelableExtra(AlarmPlaylistActivity.ALARM_PLAYLIST));
+            requireService().setPreset(activePlayer, currentPreset + 1, alarmPlaylist);
+
+            // Update the local state, in case the server doesn't push a status update.
+            List<Preset> presets = new ArrayList<>(activePlayer.getPlayerState().getPresets());
+            while (presets.size() <= currentPreset) {
+                presets.add(new Preset("", "", ""));
+            }
+            presets.set(currentPreset, new Preset(alarmPlaylist.getId(), alarmPlaylist.getName(), "audio"));
+            activePlayer.getPlayerState().setPresets(presets);
+            adapter.notifyItemChanged(currentPreset);
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(CURRENT_PRESET, currentPreset);
+    }
+
+    public static void show(Activity context) {
+        final Intent intent = new Intent(context, PresetsActivity.class)
+                .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
+        context.startActivity(intent);
+    }
+
+    private class PresetsAdapter extends RecyclerView.Adapter<PresetsAdapter.ViewHolder> {
+
+        @Override
+        public int getItemCount() {
+            return NUM_PRESETS;
+        }
+
+        @NonNull
+        @Override
+        public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            return new ViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.list_item_preset, parent, false));
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+            holder.bindView(position);
+        }
+
+        private class ViewHolder extends RecyclerView.ViewHolder {
+            private final TextView number;
+            private final TextView text1;
+            private final ImageButton play;
+
+            public ViewHolder(@NonNull View view) {
+                super(view);
+                number = view.findViewById(R.id.number);
+                text1 = view.findViewById(R.id.text1);
+                play = view.findViewById(R.id.play);
+                view.setOnClickListener(v -> selectPreset(getBindingAdapterPosition()));
+                play.setOnClickListener(v -> {
+                    if (activePlayer != null) {
+                        requireService().button(activePlayer, IRButton.values()[getBindingAdapterPosition()]);
+                    }
+                });
+            }
+
+            public void bindView(int position) {
+                Preset preset = getPreset(position);
+                number.setText(String.valueOf(position + 1));
+                text1.setText((preset != null) ? preset.text
+                        : getString(R.string.PRESETS_NOT_DEFINED, String.valueOf(position + 1)));
+                play.setVisibility((preset != null) ? View.VISIBLE : View.GONE);
+            }
+        }
+    }
+}

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/ItemIconUtils.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/ItemIconUtils.java
@@ -97,6 +97,7 @@ public class ItemIconUtils {
         result.put("hm_opmlmyapps", R.drawable.apps);
         result.put("hm_opmlappgallery", R.drawable.apps_settings);
         result.put("hm_settingsAlarm", R.drawable.alarm_clock);
+        result.put("hm_settingsPresets", R.drawable.favorites);
         result.put("hm_appletCustomizeHome", R.drawable.settings_home);
         result.put("hm_settingsPlayerNameChange", R.drawable.rename);
         result.put("hm_advancedSettings", R.drawable.settings_advanced);

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/JiveItem.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/JiveItem.java
@@ -50,6 +50,7 @@ public class JiveItem extends Item {
     public static final JiveItem EXTRAS = new JiveItem(record("extras", "home", Squeezer.getInstance().getString(R.string.EXTRAS), 50), Window.WindowStyle.HOME_MENU);
     public static final JiveItem SETTINGS = new JiveItem(record("settings", "home", Squeezer.getInstance().getString(R.string.SETTINGS), 1005), Window.WindowStyle.HOME_MENU);
     public static final JiveItem ADVANCED_SETTINGS = new JiveItem(record("advancedSettings", "settings", Squeezer.getInstance().getString(R.string.ADVANCED_SETTINGS), 105), Window.WindowStyle.TEXT_ONLY);
+    public static final JiveItem SETTINGS_PRESETS = new JiveItem(record("settingsPresets", "settings", Squeezer.getInstance().getString(R.string.menu_item_presets), 35), Window.WindowStyle.TEXT_ONLY);
     public static final JiveItem ARCHIVE = new JiveItem(record("archiveNode", "home", Squeezer.getInstance().getString(R.string.ARCHIVE_NODE), 1100), Window.WindowStyle.HOME_MENU);
     public static final JiveItem SHORTCUTS = new JiveItem(record("shortcuts", "home", Squeezer.getInstance().getString(R.string.SHORTCUTS), 10), Window.WindowStyle.HOME_MENU);
     public static final JiveItem DOWNLOAD = new JiveItem(record("downloadItem", R.string.DOWNLOAD));

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/PlayerState.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/PlayerState.java
@@ -159,6 +159,24 @@ public class PlayerState implements Parcelable {
     @NonNull
     public Map<Player.Pref, String> prefs = new HashMap<>();
 
+    /** The presets of the player, from the "preset_data" field of the status response. */
+    @NonNull
+    private List<Preset> presets = Collections.emptyList();
+
+    @NonNull
+    public List<Preset> getPresets() {
+        return presets;
+    }
+
+    public boolean setPresets(@NonNull List<Preset> presets) {
+        if (presets.equals(this.presets)) {
+            return false;
+        }
+
+        this.presets = presets;
+        return true;
+    }
+
     public boolean isPlaying() {
         return PLAY_STATE_PLAY.equals(playStatus);
     }

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Preset.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/model/Preset.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Thomas Malcher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.org.ngo.squeezer.model;
+
+import androidx.annotation.NonNull;
+
+import java.util.Map;
+import java.util.Objects;
+
+import uk.org.ngo.squeezer.Util;
+
+/**
+ * A player preset, i.e. a favorite assigned to one of the preset buttons of the player.
+ * <p>
+ * Presets are received in the "preset_data" field of the status response, which the server
+ * includes when the status request has the "menu:menu" parameter. An unassigned preset slot
+ * is an empty record.
+ */
+public class Preset {
+
+    /** The URL of the assigned item, empty if the preset slot is unassigned. */
+    @NonNull
+    public final String url;
+
+    /** The display text of the assigned item. */
+    @NonNull
+    public final String text;
+
+    /** The type of the assigned item, e.g. "audio" or "playlist". */
+    @NonNull
+    public final String type;
+
+    public Preset(Map<String, Object> record) {
+        this(Util.getStringOrEmpty(record, "URL"),
+                Util.getStringOrEmpty(record, "text"),
+                Util.getStringOrEmpty(record, "type"));
+    }
+
+    public Preset(@NonNull String url, @NonNull String text, @NonNull String type) {
+        this.url = url;
+        this.text = text;
+        this.type = type;
+    }
+
+    /** @return Whether an item is assigned to this preset slot. */
+    public boolean isSet() {
+        return !url.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Preset)) return false;
+        Preset preset = (Preset) o;
+        return url.equals(preset.url) && text.equals(preset.text) && type.equals(preset.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(url, text, type);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "Preset{url='" + url + "', text='" + text + "', type='" + type + "'}";
+    }
+}

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/BaseClient.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/BaseClient.java
@@ -20,7 +20,9 @@ import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -33,6 +35,7 @@ import uk.org.ngo.squeezer.itemlist.IServiceItemListCallback;
 import uk.org.ngo.squeezer.model.CurrentTrack;
 import uk.org.ngo.squeezer.model.Player;
 import uk.org.ngo.squeezer.model.PlayerState;
+import uk.org.ngo.squeezer.model.Preset;
 import uk.org.ngo.squeezer.model.SlimCommand;
 import uk.org.ngo.squeezer.service.event.PlayStatusChanged;
 import uk.org.ngo.squeezer.service.event.PlayerStateChanged;
@@ -113,6 +116,7 @@ abstract class BaseClient implements SlimClient {
         boolean changedVolume = playerState.setCurrentVolume(Util.getInt(tokenMap, "mixer volume"));
         boolean changedSyncMaster = playerState.setSyncMaster(Util.getString(tokenMap, "sync_master"));
         boolean changedSyncSlaves = playerState.setSyncSlaves(Arrays.stream(Util.getStringOrEmpty(tokenMap, "sync_slaves").split(",")).filter(it -> !it.isEmpty()).collect(Collectors.toList()));
+        boolean changedPresets = parsePresets(playerState, tokenMap);
         boolean changedPlayStatus = updatePlayStatus(playerState, Util.getStringOrEmpty(tokenMap, "mode"));
 
         // Playing status
@@ -127,7 +131,7 @@ abstract class BaseClient implements SlimClient {
 
         if (changedPower || changedSleep || changedSleepDuration || changedVolume
                 || changedSong || changedSongDuration || changedSongTime
-                || changedSyncMaster || changedSyncSlaves) {
+                || changedSyncMaster || changedSyncSlaves || changedPresets) {
             postPlayerStateChanged(player);
         }
 
@@ -179,6 +183,24 @@ abstract class BaseClient implements SlimClient {
 
     protected void postPlayerStateChanged(Player player) {
         repository.post(new PlayerStateChanged(player));
+    }
+
+    /**
+     * Parse the "preset_data" field of the status response, present because we request status
+     * with the "menu:menu" parameter. An unassigned preset slot is an empty record.
+     */
+    @SuppressWarnings("unchecked")
+    private boolean parsePresets(PlayerState playerState, Map<String, Object> tokenMap) {
+        Object[] presetData = (Object[]) tokenMap.get("preset_data");
+        if (presetData == null) {
+            return false;
+        }
+
+        List<Preset> presets = new ArrayList<>(presetData.length);
+        for (Object record : presetData) {
+            presets.add(new Preset((Map<String, Object>) record));
+        }
+        return playerState.setPresets(presets);
     }
 
     private boolean updatePlayStatus(PlayerState playerState, String playStatus) {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/HomeMenuHandling.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/HomeMenuHandling.java
@@ -140,6 +140,7 @@ public class HomeMenuHandling {
         homeMenu.clear();
         homeMenu.addAll(items);
         homeMenu.addAll(customShortcuts);
+        homeMenu.add(JiveItem.SETTINGS_PRESETS);
         customizeHomeMenu();
     }
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ISqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ISqueezeService.java
@@ -117,6 +117,15 @@ public interface ISqueezeService {
     boolean playlistSave(String name);
     boolean button(Player player, IRButton button);
 
+    /**
+     * Assign an item to a preset button of the supplied player.
+     *
+     * @param player The player to set the preset for.
+     * @param key The preset slot (1-based).
+     * @param playlist The item to assign to the preset slot.
+     */
+    void setPreset(Player player, int key, AlarmPlaylist playlist);
+
     void setSecondsElapsed(int seconds);
     void adjustSecondsElapsed(int seconds);
 

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -1253,6 +1253,20 @@ public class SqueezeService extends Service {
         }
 
         @Override
+        public void setPreset(Player player, int key, AlarmPlaylist playlist) {
+            if (!isConnected()) {
+                return;
+            }
+            // The web interface presets editor stores all items with type "audio", so mirror that.
+            mDelegate.command(player).cmd("jivefavorites", "set_preset")
+                    .param("key", key)
+                    .param("favorites_url", playlist.getId())
+                    .param("favorites_title", playlist.getName())
+                    .param("favorites_type", "audio")
+                    .exec();
+        }
+
+        @Override
         public void setActivePlayer(@Nullable final Player newActivePlayer, boolean continuePlaying) {
             changeActivePlayer(newActivePlayer, continuePlaying);
         }

--- a/Squeezer/src/main/res/layout/list_item_preset.xml
+++ b/Squeezer/src/main/res/layout/list_item_preset.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+ Copyright (c) 2026 Thomas Malcher
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="48dp"
+    android:layout_margin="4dp"
+    app:cardCornerRadius="4dp"
+    app:contentPadding="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/number"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="32dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:textAppearance="@style/SqueezerTextAppearance.XLarge"
+            tools:text="1" />
+
+        <TextView
+            android:id="@+id/text1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/number"
+            app:layout_constraintEnd_toStartOf="@id/play"
+            android:layout_marginStart="8dp"
+            android:ellipsize="end"
+            android:maxLines="2"
+            android:textAppearance="@style/SqueezerTextAppearance.ListItem.Primary"
+            tools:text="Radio Paradise" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/play"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_action_play"
+            app:tint="?attr/colorPrimary"
+            android:contentDescription="@string/PLAY_NOW" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/Squeezer/src/main/res/menu/now_playing_fragment_menu.xml
+++ b/Squeezer/src/main/res/menu/now_playing_fragment_menu.xml
@@ -44,6 +44,10 @@
         android:icon="@drawable/alarm_clock"/>
 
     <item
+        android:id="@+id/menu_item_presets"
+        android:title="@string/menu_item_presets"/>
+
+    <item
         android:id="@+id/menu_item_disconnect"
         android:icon="@drawable/ic_action_disconnect"
         android:title="@string/menu_item_disconnect"/>

--- a/Squeezer/src/main/res/values-da/serverstrings.xml
+++ b/Squeezer/src/main/res/values-da/serverstrings.xml
@@ -39,6 +39,7 @@ Automatically generated file. DO NOT MODIFY
   <string name='ALARM_SHORT_DAY_0'>Søn</string>
   <string name='ALARM_SHORT_DAY_1'>Man</string>
   <string name='ALARM_SET_TIME'>Indstil uret</string>
+  <string name='PRESETS_NOT_DEFINED'>Fast indstilling #%s er ikke defineret.</string>
   <string name='SETUP_PLAYTRACKALBUM_0'>Afspil kun det valgte nummer</string>
   <string name='MORE'>Mere…</string>
   <string name='SLEEP_AT_END_OF_SONG'>Slumrefunktion når nummeret er slut</string>

--- a/Squeezer/src/main/res/values-de/serverstrings.xml
+++ b/Squeezer/src/main/res/values-de/serverstrings.xml
@@ -48,6 +48,7 @@ Automatically generated file. DO NOT MODIFY
   <string name='ALARM_SHORT_DAY_3'>Mi</string>
   <string name='ALARM_SHORT_DAY_0'>So</string>
   <string name='ALARM_SHORT_DAY_1'>Mo</string>
+  <string name='PRESETS_NOT_DEFINED'>Voreinstellung %s nicht definiert.</string>
   <string name='SETUP_PLAYTRACKALBUM_0'>Nur den ausgewählten Titel wiedergeben</string>
   <string name='MORE'>Mehr</string>
   <string name='SLEEP_AT_END_OF_SONG'>Schlafmodus bei Titelende</string>

--- a/Squeezer/src/main/res/values-fr/serverstrings.xml
+++ b/Squeezer/src/main/res/values-fr/serverstrings.xml
@@ -48,6 +48,7 @@ Automatically generated file. DO NOT MODIFY
   <string name='ALARM_SHORT_DAY_3'>Me</string>
   <string name='ALARM_SHORT_DAY_0'>Di</string>
   <string name='ALARM_SHORT_DAY_1'>Lu</string>
+  <string name='PRESETS_NOT_DEFINED'>Présélection n°%s non définie.</string>
   <string name='SETUP_PLAYTRACKALBUM_0'>Lire uniquement les morceaux choisis</string>
   <string name='MORE'>Plus</string>
   <string name='SLEEP_AT_END_OF_SONG'>Veille à la fin du morceau</string>

--- a/Squeezer/src/main/res/values-nl/serverstrings.xml
+++ b/Squeezer/src/main/res/values-nl/serverstrings.xml
@@ -48,6 +48,7 @@ Automatically generated file. DO NOT MODIFY
   <string name='ALARM_SHORT_DAY_3'>wo</string>
   <string name='ALARM_SHORT_DAY_0'>zo</string>
   <string name='ALARM_SHORT_DAY_1'>ma</string>
+  <string name='PRESETS_NOT_DEFINED'>Voorinstelling #%s niet gedefinieerd.</string>
   <string name='SETUP_PLAYTRACKALBUM_0'>Alleen geselecteerde nummer afspelen</string>
   <string name='MORE'>Meer</string>
   <string name='SLEEP_AT_END_OF_SONG'>Sluimermodus aan einde van nummer</string>

--- a/Squeezer/src/main/res/values-pl/serverstrings.xml
+++ b/Squeezer/src/main/res/values-pl/serverstrings.xml
@@ -48,6 +48,7 @@ Automatically generated file. DO NOT MODIFY
   <string name='ALARM_SHORT_DAY_3'>Śr</string>
   <string name='ALARM_SHORT_DAY_0'>Ni</string>
   <string name='ALARM_SHORT_DAY_1'>Po</string>
+  <string name='PRESETS_NOT_DEFINED'>Ustawienie domyślne #%s nie zdefiniowane.</string>
   <string name='SETUP_PLAYTRACKALBUM_0'>Odtwórz tylko zaznaczony utwór</string>
   <string name='MORE'>Więcej</string>
   <string name='SLEEP_AT_END_OF_SONG'>Włącz uśpienie po zakończeniu utworu</string>

--- a/Squeezer/src/main/res/values/serverstrings.xml
+++ b/Squeezer/src/main/res/values/serverstrings.xml
@@ -48,6 +48,7 @@ Automatically generated file. DO NOT MODIFY
   <string name='ALARM_SHORT_DAY_3'>We</string>
   <string name='ALARM_SHORT_DAY_0'>Su</string>
   <string name='ALARM_SHORT_DAY_1'>Mo</string>
+  <string name='PRESETS_NOT_DEFINED'>Preset #%s not defined.</string>
   <string name='SETUP_PLAYTRACKALBUM_0'>Play only selected song</string>
   <string name='MORE'>More</string>
   <string name='SLEEP_AT_END_OF_SONG'>Sleep at end of song</string>

--- a/Squeezer/src/main/res/values/strings.xml
+++ b/Squeezer/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="mute_all">Mute all players</string>
     <string name="minutes">minutes</string>
     <string name="menu_item_players">Players</string>
+    <string name="menu_item_presets">Presets</string>
     <string name="menu_item_settings_label">Settings</string>
     <string name="menu_item_about_label">About</string>
     <string name="menu_item_view">View</string>


### PR DESCRIPTION
This adds a Presets Editor to Squeezer so presets can be viewed and assigned from the
app, mirroring the web editor. It reuses parts of the Alarm settings view.

Disclosure: This is my first ever android code, it is mainly written by AI. I reviewed it and the changes seem reasonable.
Request for review, comments and merge. Thanks!

### What it adds

- **Presets screen** (`PresetsActivity`): shows the 6 preset slots for the active player,
  each with its current assignment and a play button to test it. Tap
  a slot to assign a favorite/playlist from the same categorized picker used by the
  alarm playlist screen. Reachable from the Now Playing overflow menu and from
  Home > Settings, next to Alarms.
- **Reads presets from the existing status subscription**: the player `status` request
  already includes `menu:menu`, which makes the server return `preset_data` — this was
  previously received but ignored. No new request needed.
- **Writes presets via the `jivefavorites set_preset` command** (the same one the web
  editor and SqueezePlay-based players use).
- Minor refactor: the alarm-playlist picker (`AlarmPlaylistActivity` and its two
  adapters) took an `Alarm` purely to read its `playListId` for highlighting the current
  selection. Generalized it to take a plain URL string so both alarms and presets can
  share it.

### Open
- Clearing an assigned slot isn't possible yet — no sure if needed;
- Terminology inconsistency noticed in existing translations: the new Presets screen
  reuses server-string tokens (e.g. `PRESETS_NOT_DEFINED`) pulled verbatim from LMS's own
  translations via `updateSlimStrings`. In English, German these translate to "preset" literally (German "Voreinstellung"), 
  while the existing, independently translated home-screen widget strings (`remote_presetNDescription`) 
  call the same buttons "favorite" instead (German "Favoritentaste").


