### PR TITLE
implemented double tap skip option

### DIFF
--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/Preferences.java
@@ -131,6 +131,10 @@ public final class Preferences {
     // Volume up/down increments
     private static final String KEY_VOLUME_INCREMENTS = "squeezer.volumeIncrements";
 
+    // Double tap volume to skip track
+    public static final String KEY_DOUBLE_TAP_VOLUME_SKIP = "squeezer.double_tap_volume_skip";
+    public static final String KEY_DOUBLE_TAP_VOLUME_TIMEOUT = "squeezer.double_tap_volume_timeout";
+
     // Adjust volume for sync group when applicable
     private static final String KEY_GROUP_VOLUME = "squeezer.groupVolume";
 
@@ -567,6 +571,22 @@ public final class Preferences {
 
     public void setGroupVolume(boolean groupVolume) {
         sharedPreferences.edit().putBoolean(Preferences.KEY_GROUP_VOLUME, groupVolume).apply();
+    }
+
+    public boolean isDoubleTapVolumeSkip() {
+        return sharedPreferences.getBoolean(KEY_DOUBLE_TAP_VOLUME_SKIP, false);
+    }
+
+    public void setDoubleTapVolumeSkip(boolean doubleTapVolumeSkip) {
+        sharedPreferences.edit().putBoolean(KEY_DOUBLE_TAP_VOLUME_SKIP, doubleTapVolumeSkip).apply();
+    }
+
+    public int getDoubleTapVolumeTimeout() {
+        return sharedPreferences.getInt(KEY_DOUBLE_TAP_VOLUME_TIMEOUT, 400);
+    }
+
+    public void setDoubleTapVolumeTimeout(int timeoutMs) {
+        sharedPreferences.edit().putInt(KEY_DOUBLE_TAP_VOLUME_TIMEOUT, timeoutMs).apply();
     }
 
     public int getFadeInSecs() {

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/SettingsFragment.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/SettingsFragment.java
@@ -198,6 +198,7 @@ public class SettingsFragment  extends PreferenceFragmentCompat implements
 
     private void fillNowPlayingPreferences(Preferences preferences) {
         this.<SwitchPreferenceCompat>requirePreference(Preferences.KEY_NOW_PLAYING_VOLUME).setChecked(preferences.nowPlayingVolume());
+        this.<SwitchPreferenceCompat>requirePreference(Preferences.KEY_DOUBLE_TAP_VOLUME_SKIP).setChecked(preferences.isDoubleTapVolumeSkip());
         this.<SwitchPreferenceCompat>requirePreference(Preferences.KEY_TRACK_COUNT).setChecked(preferences.showTrackCount());
         this.<SwitchPreferenceCompat>requirePreference(Preferences.KEY_TECHNICAL_INFO).setChecked(preferences.showTechnicalInfo());
         this.<SwitchPreferenceCompat>requirePreference(Preferences.KEY_COMPOSER_LINE).setChecked(preferences.addComposerLine());

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/dialog/VolumeSettings.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/dialog/VolumeSettings.java
@@ -37,6 +37,11 @@ public class VolumeSettings extends DialogFragment {
         Slider volumeIncrements = view.findViewById(R.id.volume_increments);
         volumeIncrements.setValue(preferences.getVolumeIncrements());
 
+        SwitchMaterial doubleTapVolumeSkip = view.findViewById(R.id.double_tap_volume_skip);
+        TextView doubleTapVolumeSkipHint = view.findViewById(R.id.double_tap_volume_skip_hint);
+        doubleTapVolumeSkip.setOnCheckedChangeListener((buttonView, isChecked) -> doubleTapVolumeSkipHint.setText(isChecked ? R.string.settings_double_tap_volume_skip_on : R.string.settings_double_tap_volume_skip_off));
+        doubleTapVolumeSkip.setChecked(preferences.isDoubleTapVolumeSkip());
+
         boolean canAdjustVolumeForSyncGroup = service.canAdjustVolumeForSyncGroup();
         SwitchMaterial groupVolume = view.findViewById(R.id.group_volume);
         TextView groupVolumeHint = view.findViewById(R.id.group_volume_hint);
@@ -62,6 +67,7 @@ public class VolumeSettings extends DialogFragment {
                 .setPositiveButton(android.R.string.ok, (dialog, id) -> {
                     preferences.setBackgroundVolume(backgroundVolume.isChecked());
                     preferences.setVolumeIncrements((int) volumeIncrements.getValue());
+                    preferences.setDoubleTapVolumeSkip(doubleTapVolumeSkip.isChecked());
                     preferences.setGroupVolume(groupVolume.isChecked());
                     service.preferenceChanged(preferences, null);
                     service.playerPref(Player.Pref.DIGITAL_VOLUME_CONTROL, fixedVolume.isChecked() ? "1" : "0");

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ISqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/ISqueezeService.java
@@ -128,6 +128,7 @@ public interface ISqueezeService {
     void toggleMute(Player player);
     void setVolumeTo(int newVolume);
     void adjustVolume(int direction);
+    void onVolumeAdjustKeyPress(int direction);
 
     /**
      * @return  whether the active player is in a sync group where the player's volumes are not synced by LMS

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/service/SqueezeService.java
@@ -59,6 +59,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import uk.org.ngo.squeezer.volume.DoubleTapVolumeController;
 import java.util.stream.Collectors;
 
 import uk.org.ngo.squeezer.NowPlayingActivity;
@@ -150,6 +152,7 @@ public class SqueezeService extends Service {
     private static final String ACTION_DISCONNECT = "disconnect";
 
     private SqueezerVolumeProvider mVolumeProvider;
+    private DoubleTapVolumeController mDoubleTapVolumeController;
 
     @Override
     public void onCreate() {
@@ -163,6 +166,23 @@ public class SqueezeService extends Service {
         mDelegate = new SlimDelegate(repository);
         homeMenuHandling = mDelegate.getHomeMenuHandling();
         randomPlayDelegate = new RandomPlayDelegate(mDelegate);
+
+        mDoubleTapVolumeController = new DoubleTapVolumeController(new DoubleTapVolumeController.Callback() {
+            @Override
+            public void adjustVolume(int direction) {
+                squeezeService.adjustVolume(direction);
+            }
+
+            @Override
+            public void nextTrack() {
+                squeezeService.nextTrack();
+            }
+
+            @Override
+            public boolean isPlaying() {
+                return SqueezeService.this.isPlaying();
+            }
+        });
 
         Squeezer.getPreferences(preferences -> {
             cachePreferences(preferences);
@@ -211,6 +231,10 @@ public class SqueezeService extends Service {
         mFadeInSecs = preferences.getFadeInSecs();
         mGroupVolume = preferences.isGroupVolume();
         mVolumeProvider = new SqueezerVolumeProvider(preferences.getVolumeIncrements());
+        if (mDoubleTapVolumeController != null) {
+            mDoubleTapVolumeController.setEnabled(preferences.isDoubleTapVolumeSkip());
+            mDoubleTapVolumeController.setTimeoutMs(preferences.getDoubleTapVolumeTimeout());
+        }
         if (squeezeService.isConnected()) {
             if (preferences.isBackgroundVolume()) {
                 mediaSession.setPlaybackToRemote(mVolumeProvider);
@@ -934,6 +958,11 @@ public class SqueezeService extends Service {
         }
 
         @Override
+        public void onVolumeAdjustKeyPress(int direction) {
+            mDoubleTapVolumeController.onAdjustVolume(direction);
+        }
+
+        @Override
         public void adjustVolume(int direction) {
             Set<Player> syncGroup = mDelegate.getVolumeSyncGroup(mGroupVolume);
             int adjust = direction * mVolumeProvider.step;
@@ -1564,7 +1593,7 @@ public class SqueezeService extends Service {
 
         @Override
         public void onAdjustVolume(int direction) {
-            squeezeService.adjustVolume(direction);
+            mDoubleTapVolumeController.onAdjustVolume(direction);
         }
 
         @Override

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/volume/DoubleTapVolumeController.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/volume/DoubleTapVolumeController.java
@@ -1,0 +1,162 @@
+package uk.org.ngo.squeezer.volume;
+
+import android.os.SystemClock;
+import android.util.Log;
+
+/**
+ * Handles double-tap volume button gestures with optimistic volume adjustment and reversal.
+ * On the first volume tap, the volume is adjusted immediately for zero-latency response.
+ *
+ * If the SAME volume key is tapped again within the timeout window (e.g. 400ms), the first
+ * volume change is reverted and a track skip is triggered.
+ *
+ * Rapid key-repeats (such as from holding down the volume button) are ignored to prevent
+ * accidental triggers.
+ */
+public class DoubleTapVolumeController {
+
+    private static final String TAG = "DoubleTapVolume";
+
+    public interface Callback {
+        void adjustVolume(int direction);
+        void nextTrack();
+        boolean isPlaying();
+    }
+
+    public interface Clock {
+        long elapsedRealtime();
+    }
+
+    private static final Clock SYSTEM_CLOCK = () -> {
+        try {
+            return SystemClock.elapsedRealtime();
+        } catch (Throwable t) {
+            return System.currentTimeMillis();
+        }
+    };
+    private static final int DEFAULT_MIN_REPEAT_INTERVAL_MS = 60;
+    private static final int DEFAULT_COOLDOWN_MS = 250;
+
+    private final Callback callback;
+    private final Clock clock;
+    private final int minRepeatIntervalMs;
+    private final int cooldownMs;
+
+    private boolean enabled;
+    private int timeoutMs = 400;
+
+    private int lastDirection = 0;
+    private long lastTapTime = 0;
+    private long inCooldownUntil = 0;
+
+    public DoubleTapVolumeController(Callback callback) {
+        this(callback, SYSTEM_CLOCK, DEFAULT_MIN_REPEAT_INTERVAL_MS, DEFAULT_COOLDOWN_MS);
+    }
+
+    public DoubleTapVolumeController(Callback callback, Clock clock, int minRepeatIntervalMs, int cooldownMs) {
+        this.callback = callback;
+        this.clock = clock;
+        this.minRepeatIntervalMs = minRepeatIntervalMs;
+        this.cooldownMs = cooldownMs;
+    }
+
+    private static void logD(String msg) {
+        try {
+            Log.d(TAG, msg);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    private static void logI(String msg) {
+        try {
+            Log.i(TAG, msg);
+        } catch (Throwable ignored) {
+        }
+    }
+
+    public synchronized void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        logI("Double-tap volume skip enabled=" + enabled);
+        if (!enabled) {
+            reset();
+        }
+    }
+
+    public synchronized boolean isEnabled() {
+        return enabled;
+    }
+
+    public synchronized void setTimeoutMs(int timeoutMs) {
+        this.timeoutMs = timeoutMs;
+        logI("Double-tap volume timeout set to " + timeoutMs + "ms");
+    }
+
+    public synchronized int getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public synchronized void reset() {
+        lastDirection = 0;
+        lastTapTime = 0;
+        inCooldownUntil = 0;
+    }
+
+    /**
+     * Handles a volume adjustment event.
+     *
+     * @param direction +1 for volume up, -1 for volume down
+     */
+    public synchronized void onAdjustVolume(int direction) {
+        if (direction == 0) {
+            // Ignore no-op / ADJUST_SAME / key-release events from MediaSession
+            return;
+        }
+
+        if (!enabled) {
+            logD("Disabled -> adjusting volume: " + direction);
+            callback.adjustVolume(direction);
+            return;
+        }
+
+        long now = clock.elapsedRealtime();
+
+        // Ignore events during post-skip cooldown window
+        if (now < inCooldownUntil) {
+            logD("Ignoring event during post-skip cooldown (remaining: " + (inCooldownUntil - now) + "ms)");
+            return;
+        }
+
+        long elapsed = now - lastTapTime;
+
+        // Ignore rapid key repeats (e.g. holding down the volume key)
+        if (lastDirection != 0 && direction == lastDirection && elapsed < minRepeatIntervalMs) {
+            logD("Ignoring rapid key repeat (elapsed: " + elapsed + "ms < " + minRepeatIntervalMs + "ms)");
+            return;
+        }
+
+        // Check if this is a valid double-tap of the same key within timeout
+        if (lastDirection != 0 && direction == lastDirection && elapsed <= timeoutMs) {
+            // Revert optimistic volume adjustment from first tap (undoing the volume change)
+            callback.adjustVolume(-direction);
+
+            if (callback.isPlaying()) {
+                logI("Double-tap detected while playing! elapsed=" + elapsed + "ms, direction=" + direction + ". Reverted volume and skipping track.");
+                callback.nextTrack();
+            } else {
+                logI("Double-tap detected while stopped/paused! elapsed=" + elapsed + "ms, direction=" + direction + ". Reverted volume (undone, no track skip).");
+            }
+
+            // Reset and enter cooldown
+            lastDirection = 0;
+            lastTapTime = 0;
+            inCooldownUntil = now + cooldownMs;
+            return;
+        }
+
+        // First tap (or new direction / timed out) -> apply volume immediately
+        logD("First tap / new tap: direction=" + direction + ", elapsed=" + elapsed + "ms. Applying optimistic volume.");
+        lastDirection = direction;
+        lastTapTime = now;
+        callback.adjustVolume(direction);
+    }
+}

--- a/Squeezer/src/main/java/uk/org/ngo/squeezer/volume/VolumeKeysDelegate.java
+++ b/Squeezer/src/main/java/uk/org/ngo/squeezer/volume/VolumeKeysDelegate.java
@@ -33,7 +33,7 @@ public class VolumeKeysDelegate {
         if (service == null) {
             return false;
         }
-        service.adjustVolume(direction);
+        service.onVolumeAdjustKeyPress(direction);
         return true;
     }
 

--- a/Squeezer/src/main/res/layout/volume_settings.xml
+++ b/Squeezer/src/main/res/layout/volume_settings.xml
@@ -81,11 +81,38 @@
             android:stepSize="1" />
 
         <TextView
+            android:id="@+id/double_tap_volume_skip_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/volume_increments"
+            app:layout_constraintEnd_toStartOf="@id/double_tap_volume_skip"
+            style="@style/SqueezerTextAppearance.Preference.Title"
+            android:text="@string/settings_double_tap_volume_skip_title"/>
+        <TextView
+            android:id="@+id/double_tap_volume_skip_hint"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/double_tap_volume_skip_title"
+            app:layout_constraintEnd_toStartOf="@id/double_tap_volume_skip"
+            style="@style/SqueezerTextAppearance.Preference.Subtext"
+            android:text="@string/settings_double_tap_volume_skip_off"/>
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/double_tap_volume_skip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/double_tap_volume_skip_title"
+            app:layout_constraintBottom_toBottomOf="@id/double_tap_volume_skip_hint" />
+
+        <TextView
             android:id="@+id/group_volume_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/volume_increments"
+            app:layout_constraintTop_toBottomOf="@id/double_tap_volume_skip_hint"
             app:layout_constraintEnd_toStartOf="@id/group_volume"
             android:layout_marginTop="16dp"
             style="@style/SqueezerTextAppearance.Preference.Title"

--- a/Squeezer/src/main/res/values/strings.xml
+++ b/Squeezer/src/main/res/values/strings.xml
@@ -78,6 +78,9 @@
     <string name="settings_background_volume_on">Allow changing player volume even when the app is not visible.</string>
     <string name="settings_volume_increment_title">Volume up/down increments</string>
     <string name="settings_volume_increment_summary">Set the increments for the phone volume buttons</string>
+    <string name="settings_double_tap_volume_skip_title">Double-tap volume to skip</string>
+    <string name="settings_double_tap_volume_skip_off">Press volume buttons to change volume only.</string>
+    <string name="settings_double_tap_volume_skip_on">Double-tap volume up or down quickly to skip to next track.</string>
     <string name="settings_fadeinsecs_title">Fade in duration</string>
     <string name="settings_fadeinsecs_summary">Enter the amount of time to take to fade in when
         unpausing, in seconds. Enter 0 to disable fade in.

--- a/Squeezer/src/main/res/xml/preferences.xml
+++ b/Squeezer/src/main/res/xml/preferences.xml
@@ -61,6 +61,12 @@
             android:title="@string/volume"/>
 
         <SwitchPreferenceCompat
+            android:key="squeezer.double_tap_volume_skip"
+            android:summaryOff="@string/settings_double_tap_volume_skip_off"
+            android:summaryOn="@string/settings_double_tap_volume_skip_on"
+            android:title="@string/settings_double_tap_volume_skip_title"/>
+
+        <SwitchPreferenceCompat
             android:key="squeezer.show_track_count"
             android:summaryOff="@string/settings_show_track_number_off"
             android:summaryOn="@string/settings_show_track_number_on"

--- a/Squeezer/src/test/java/uk/org/ngo/squeezer/volume/DoubleTapVolumeControllerTest.java
+++ b/Squeezer/src/test/java/uk/org/ngo/squeezer/volume/DoubleTapVolumeControllerTest.java
@@ -1,0 +1,210 @@
+package uk.org.ngo.squeezer.volume;
+
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DoubleTapVolumeControllerTest extends TestCase {
+
+    private static class TestClock implements DoubleTapVolumeController.Clock {
+        private long currentTime = 1000;
+
+        @Override
+        public long elapsedRealtime() {
+            return currentTime;
+        }
+
+        public void advance(long ms) {
+            currentTime += ms;
+        }
+    }
+
+    private static class TestCallback implements DoubleTapVolumeController.Callback {
+        final List<Integer> volumeAdjustments = new ArrayList<>();
+        int nextTrackCalls = 0;
+        boolean playing = true;
+
+        @Override
+        public void adjustVolume(int direction) {
+            volumeAdjustments.add(direction);
+        }
+
+        @Override
+        public void nextTrack() {
+            nextTrackCalls++;
+        }
+
+        @Override
+        public boolean isPlaying() {
+            return playing;
+        }
+    }
+
+    private TestClock clock;
+    private TestCallback callback;
+    private DoubleTapVolumeController controller;
+
+    @Override
+    protected void setUp() {
+        clock = new TestClock();
+        callback = new TestCallback();
+        controller = new DoubleTapVolumeController(callback, clock, 60, 250);
+        controller.setEnabled(true);
+        controller.setTimeoutMs(400);
+    }
+
+    public void testDisabled() {
+        controller.setEnabled(false);
+
+        controller.onAdjustVolume(1);
+        clock.advance(150);
+        controller.onAdjustVolume(1);
+
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(0));
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(1));
+        assertEquals(0, callback.nextTrackCalls);
+    }
+
+    public void testSingleTap() {
+        controller.onAdjustVolume(1);
+
+        assertEquals(1, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(0));
+        assertEquals(0, callback.nextTrackCalls);
+    }
+
+    public void testDoubleTapSameKeyWithinTimeout() {
+        // First tap
+        controller.onAdjustVolume(1);
+        assertEquals(1, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(0));
+
+        // Second tap at 200ms
+        clock.advance(200);
+        controller.onAdjustVolume(1);
+
+        // Volume should be reverted (-1) and next track called
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(-1), callback.volumeAdjustments.get(1));
+        assertEquals(1, callback.nextTrackCalls);
+    }
+
+    public void testDoubleTapDownKeyWithinTimeout() {
+        // First tap down
+        controller.onAdjustVolume(-1);
+        assertEquals(1, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(-1), callback.volumeAdjustments.get(0));
+
+        // Second tap down at 250ms
+        clock.advance(250);
+        controller.onAdjustVolume(-1);
+
+        // Volume should be reverted (+1) and next track called
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(1));
+        assertEquals(1, callback.nextTrackCalls);
+    }
+
+    public void testDoubleTapWhileStoppedRevertsVolumeWithoutSkip() {
+        callback.playing = false;
+
+        // First tap
+        controller.onAdjustVolume(1);
+        assertEquals(1, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(0));
+
+        // Second tap at 200ms
+        clock.advance(200);
+        controller.onAdjustVolume(1);
+
+        // Volume should be reverted (-1) but next track NOT called
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(-1), callback.volumeAdjustments.get(1));
+        assertEquals(0, callback.nextTrackCalls);
+    }
+
+    public void testDoubleTapWithZeroEventsInterleaved() {
+        // Tap 1
+        controller.onAdjustVolume(1);
+        assertEquals(1, callback.volumeAdjustments.size());
+
+        // Interleaved direction=0 (from Android MediaSession key release) at 3ms
+        clock.advance(3);
+        controller.onAdjustVolume(0);
+        assertEquals(1, callback.volumeAdjustments.size());
+
+        // Tap 2 at 180ms
+        clock.advance(177);
+        controller.onAdjustVolume(1);
+
+        // Should successfully trigger double tap
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(-1), callback.volumeAdjustments.get(1));
+        assertEquals(1, callback.nextTrackCalls);
+    }
+
+    public void testDifferentKeysDoNotSkip() {
+        // Tap UP
+        controller.onAdjustVolume(1);
+        assertEquals(1, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(0));
+
+        // Tap DOWN at 150ms
+        clock.advance(150);
+        controller.onAdjustVolume(-1);
+
+        // Both volumes applied, no reversion, no skip
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(-1), callback.volumeAdjustments.get(1));
+        assertEquals(0, callback.nextTrackCalls);
+    }
+
+    public void testSlowTapDoesNotSkip() {
+        // Tap 1
+        controller.onAdjustVolume(1);
+        assertEquals(1, callback.volumeAdjustments.size());
+
+        // Tap 2 at 450ms (> 400ms timeout)
+        clock.advance(450);
+        controller.onAdjustVolume(1);
+
+        // Second tap is treated as a new first tap
+        assertEquals(2, callback.volumeAdjustments.size());
+        assertEquals(Integer.valueOf(1), callback.volumeAdjustments.get(1));
+        assertEquals(0, callback.nextTrackCalls);
+    }
+
+    public void testKeyRepeatSuppressed() {
+        // Initial tap
+        controller.onAdjustVolume(1);
+        assertEquals(1, callback.volumeAdjustments.size());
+
+        // OS key repeat event at 40ms (< 60ms min repeat interval)
+        clock.advance(40);
+        controller.onAdjustVolume(1);
+
+        // Ignored
+        assertEquals(1, callback.volumeAdjustments.size());
+        assertEquals(0, callback.nextTrackCalls);
+    }
+
+    public void testCooldownAfterSkip() {
+        // Double tap
+        controller.onAdjustVolume(1);
+        clock.advance(200);
+        controller.onAdjustVolume(1);
+
+        assertEquals(1, callback.nextTrackCalls);
+        assertEquals(2, callback.volumeAdjustments.size());
+
+        // Accidental 3rd tap at 100ms after skip (< 250ms cooldown)
+        clock.advance(100);
+        controller.onAdjustVolume(1);
+
+        // Ignored during cooldown
+        assertEquals(1, callback.nextTrackCalls);
+        assertEquals(2, callback.volumeAdjustments.size());
+    }
+}


### PR DESCRIPTION
Per my comment in https://github.com/kaaholst/android-squeezer/issues/895

This change is a setting (default off) for double tap vol up or down within 400ms, to skip forward one song, only when state is currently playing for the selected player.

It is optimistic, so it avoids any latency if you are just using normal volume keys up or down at normal pace. 

If the double tap comes in, I went with the "revert" the optimistic volume change, which in my testing has minimal noticable impact.

